### PR TITLE
Adding support for more then just app.py

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -5,6 +5,7 @@ Contains commands for deploying chalice.
 """
 import os
 import json
+import sys
 
 import click
 import botocore.exceptions
@@ -76,8 +77,10 @@ def load_chalice_app(project_dir):
     app_py = os.path.join(project_dir, 'app.py')
     with open(app_py) as f:
         g = {}
+        sys.path.append( project_dir )
         contents = f.read()
         exec contents in g
+        sys.path.remove( project_dir )
         return g['app']
 
 

--- a/chalice/deployer.py
+++ b/chalice/deployer.py
@@ -661,6 +661,7 @@ class LambdaDeploymentPackager(object):
             os.makedirs(os.path.dirname(deployment_package_filename))
         with zipfile.ZipFile(deployment_package_filename, 'w',
                              compression=zipfile.ZIP_DEFLATED) as z:
+            self._add_internal_requirement_files( z, project_dir )
             self._add_py_deps(z, deps_dir)
             self._add_app_files(z, project_dir)
         return deployment_package_filename
@@ -731,6 +732,42 @@ class LambdaDeploymentPackager(object):
                 contents = f.read()
         return hashlib.md5(contents).hexdigest()
 
+    def _is_dir_in_zip(self, z, name):
+        return any(x.startswith("%s/" % name.rstrip("/")) for x in z.namelist())
+
+    def _is_file_in_zip(self, z, fileName):
+        if fileName in z.namelist():
+            return True
+        return False
+
+    def _add_files_to_zip( self, outputZip, project_dir, file_or_directory ):
+        module_path = os.path.join(project_dir, file_or_directory)
+        if not os.path.isfile( module_path ):
+            if not self._is_dir_in_zip( outputZip, file_or_directory):
+                if os.path.isdir( module_path ):
+                    for dirpath,dirs,files in os.walk( module_path ):
+                        for f in files:
+                            fn = os.path.join(dirpath, f)
+                            in_zip_filename = os.path.join( file_or_directory, f )
+                            outputZip.write(fn, in_zip_filename, zipfile.ZIP_DEFLATED )
+
+        elif not self._is_file_in_zip( outputZip, file_or_directory ):
+            outputZip.write( module_path, file_or_directory, zipfile.ZIP_DEFLATED )
+
+    def _add_internal_requirement_files( self, outputZip, project_dir ):
+        for entry in self._get_internal_requirements_file_list( project_dir ):
+            self._add_files_to_zip( outputZip, project_dir, entry )
+
+    def _get_internal_requirements_file_list( self, project_dir ):
+        requiredFilesList = []
+        internal_requirements_file = os.path.join(project_dir, 'internal_requirements.txt')
+        if os.path.isfile( internal_requirements_file ):
+            with open( internal_requirements_file ) as f:
+                for line in f:
+                    line = line.strip()
+                    requiredFilesList.append( line )
+        return requiredFilesList
+
     def inject_latest_app(self, deployment_package_filename, project_dir):
         # type: (str, str) -> None
         """Inject latest version of chalice app into a zip package.
@@ -752,13 +789,14 @@ class LambdaDeploymentPackager(object):
         # a way to do this efficiently so we need to create a new
         # zip file that has all the same stuff except for the new
         # app file.
-        # TODO: support more than just an app.py file.
         print "Regen deployment package..."
         tmpzip = deployment_package_filename + '.tmp.zip'
+        requiredFilesList  = self._get_internal_requirements_file_list( project_dir )
+        requiredFilesList.append( 'app.py' )
         with zipfile.ZipFile(deployment_package_filename, 'r') as inzip:
             with zipfile.ZipFile(tmpzip, 'w') as outzip:
                 for el in inzip.infolist():
-                    if el.filename == 'app.py':
+                    if el.filename in requiredFilesList:
                         continue
                     else:
                         contents = inzip.read(el.filename)
@@ -767,6 +805,9 @@ class LambdaDeploymentPackager(object):
                 app_py = os.path.join(project_dir, 'app.py')
                 assert os.path.isfile(app_py), app_py
                 outzip.write(app_py, 'app.py')
+                # and all your internal required files
+                self._add_internal_requirement_files( outzip, project_dir )
+                                
         shutil.move(tmpzip, deployment_package_filename)
 
 


### PR DESCRIPTION
Adding support for more then just app.py.

The only way I could currently think to make this work was to have an explicit list of files that need to get updated other then the app.py, used to add them to the zip file. Since we're already relying on people having a requirements.txt for pip installation the new file is called internal_requirements.txt .

It is a \n separated list of files to include in the deploy. Supports both files in sub folders and files in the same directory as the app.py.

I didn't create a test for this use case since I wasn't exactly sure about the formatting for them given that this test relies on multiple files. also the current tests before I changed anything didnt succeed for me.

Pasted below is my example files for testing (not included so as to not pollute the project):
## ./app.py

from chalice import Chalice
from package import fibo
import fibo_2

app = Chalice(app_name='subfolders')
app.debug = True

@app.route('/')
def index():
    fibList = fibo.fib2(10)
    fibList2 = fibo_2.fib2(10)
    return {'hello': 'world', 'fib' : fibList, 'fib2': fibList2 }
## ./fibo_2.py
# Fibonacci numbers module

def fib2(n):   # return Fibonacci series up to n
    result = []
    a, b = 0, 1
    while b < n:
        result.append(b)
        a, b = b, a+b
    return result
## ./package/fibo.py
# Fibonacci numbers module

def fib(n):    # write Fibonacci series up to n
    a, b = 0, 1
    while b < n:
        print b,
        a, b = b, a+b

def fib2(n):   # return Fibonacci series up to n
    result = []
    a, b = 0, 1
    while b < n:
        result.append(b)
        a, b = b, a+b
    return result
## ./package/**init**.py
## ./internal_requirements.txt

package
fibo_2.py

And that's it. Any feedback is appreciated and thanks for the easy tool, it was just missing this one feature to really be useful.
