### PR TITLE
Fix samples in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -210,8 +210,8 @@ parts of the URI:
         return {'hello': 'world'}
 
     @app.route('/cities/{city}')
-    def state_of_city(name):
-        return {'state': CITIES_TO_STATE[name]}
+    def state_of_city(city):
+        return {'state': CITIES_TO_STATE[city]}
 
 
 In the example above we've now added a ``state_of_city`` view that allows
@@ -326,12 +326,12 @@ to the user.  Here's the updated code:
     from chalice import BadRequestError
 
     @app.route('/cities/{city}')
-    def state_of_city(name):
+    def state_of_city(city):
         try:
-            return {'state': CITIES_TO_STATE[name]}
+            return {'state': CITIES_TO_STATE[city]}
         except KeyError:
             raise BadRequestError("Unknown city '%s', valid choices are: %s" % (
-                name, ', '.join(CITIES_TO_STATE.keys())))
+                city, ', '.join(CITIES_TO_STATE.keys())))
 
 
 Save and deploy these changes::


### PR DESCRIPTION
The /cities/{city} examples later refer to the parameter as `name` instead of `city`