### PR TITLE
Check for trailing slashes before deploying app

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -131,6 +131,10 @@ def deploy(ctx, project_dir, autogen_policy, stage):
                                  "region value in our ~/.aws/config file.")
         e.exit_code = 2
         raise e
+    except Exception as e:
+        e = click.ClickException("Error when deploying: %s" % e)
+        e.exit_code = 1
+        raise e
 
 
 @cli.command()

--- a/chalice/deployer.py
+++ b/chalice/deployer.py
@@ -115,6 +115,7 @@ def build_url_trie(routes):
     :return: A prefix trie of URL patterns.
 
     """
+    _validate_routes(routes)
     root = node('', '/')
     for route in routes:
         if route == '/':
@@ -138,6 +139,33 @@ def build_url_trie(routes):
         current['is_route'] = True
         current['route_entry'] = routes[route]
     return root['children'].values()[0]
+
+
+def validate_configuration(config):
+    # type: (Dict[str, Any]) -> None
+    """Validate app configuration.
+
+    The purpose of this method is to provide a fail fast mechanism
+    for anything we know is going to fail deployment.
+    We can detect common error cases and provide the user with helpful
+    error messages.
+
+    """
+    routes = config['chalice_app'].routes
+    _validate_routes(routes)
+
+
+def _validate_routes(routes):
+    # type: (Dict[str, Any]) -> None
+    # We're trying to validate any kind of route that will fail
+    # when we send the request to API gateway.
+    # We check for:
+    #
+    # * any routes that end with a trailing slash.
+    for route in routes:
+        if route != '/' and route.endswith('/'):
+            raise ValueError("Route cannot end with a trailing slash: %s"
+                             % route)
 
 
 def node(name, uri_path, is_route=False):
@@ -204,6 +232,7 @@ class Deployer(object):
                 project config file.
 
         """
+        validate_configuration(config)
         self._deploy_lambda(config)
         rest_api_id, region_name, stage = self._deploy_api_gateway(config)
         print (

--- a/tests/unit/test_deployer.py
+++ b/tests/unit/test_deployer.py
@@ -4,8 +4,9 @@ from pytest import fixture
 from chalice.deployer import build_url_trie
 from chalice.deployer import APIGatewayResourceCreator
 from chalice.deployer import FULL_PASSTHROUGH, ERROR_MAPPING
-from chalice.deployer import ResourceQuery
+from chalice.deployer import ResourceQuery, validate_configuration
 from chalice.app import RouteEntry, ALL_ERRORS
+from chalice.app import Chalice
 
 from botocore.stub import Stubber
 import botocore.session
@@ -91,6 +92,16 @@ def test_multiple_routes_on_single_spine():
                      children={'bar':  n('bar', '/foo/bar', is_route=True)})
         }
     )
+
+
+def test_trailing_slash_routes_result_in_error():
+    app = Chalice('appname')
+    app.routes = {'/trailing-slash/': None}
+    config = {
+        'chalice_app':  app,
+    }
+    with pytest.raises(ValueError):
+        validate_configuration(config)
 
 
 def add_expected_calls_to_map_error(error_cls, gateway_stub):


### PR DESCRIPTION
These don't work in API gateway, so we should error out
before we deploy.

```
$ chalice deploy
Error: Error when deploying: Route cannot end with a trailing slash: /trailing-slash/
```

Fixes #65