### PR TITLE
Validate duplicate routes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,3 +14,5 @@ Next Release
 * Improve error validation when routes containing a
   trailing ``/`` char
   (`#65 <https://github.com/awslabs/chalice/issues/65>`__)
+* Validate duplicate route entries
+  (`#79 <https://github.com/awslabs/chalice/issues/79>`__)

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -147,6 +147,10 @@ class Chalice(object):
         authorizer_id = kwargs.get('authorizer_id', None)
         api_key_required = kwargs.get('api_key_required', None)
 
+        if path in self.routes:
+            raise ValueError(
+                "Duplicate route detected: '%s'\n"
+                "URL paths must be unique." % path)
         self.routes[path] = RouteEntry(
             view_func,
             name,

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -77,7 +77,14 @@ def load_chalice_app(project_dir):
     with open(app_py) as f:
         g = {}
         contents = f.read()
-        exec contents in g
+        try:
+            exec contents in g
+        except Exception as e:
+            exception = click.ClickException(
+                "Unable to import your app.py file: %s" % e
+            )
+            exception.exit_code = 2
+            raise exception
         return g['app']
 
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -115,3 +115,16 @@ def test_can_access_raw_body():
 
     result = demo(event, context=None)
     assert result == {'rawbody': '{"hello": "world"}'}
+
+
+def test_error_on_duplicate_routes():
+    demo = app.Chalice('app-name')
+
+    @demo.route('/index', methods=['PUT'])
+    def index_view():
+        return {'foo': 'bar'}
+
+    with pytest.raises(ValueError):
+        @demo.route('/index', methods=['POST'])
+        def index_post():
+            return {'foo': 'bar'}


### PR DESCRIPTION
You now will get:

```
$ chalice deploy
Error: Unable to import your app.py file: Duplicate route detected:
'/foo'
URL paths must be unique.
```

Fixes #79.