### PR TITLE
Ignore lambda expressions in analyzer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,3 +16,5 @@ Next Release
   (`#65 <https://github.com/awslabs/chalice/issues/65>`__)
 * Validate duplicate route entries
   (`#79 <https://github.com/awslabs/chalice/issues/79>`__)
+* Ignore lambda expressions in policy analyzer
+  (`#74 <https://github.com/awslabs/chalice/issues/74>`__)

--- a/chalice/analyzer.py
+++ b/chalice/analyzer.py
@@ -368,6 +368,14 @@ class SymbolTableTypeInfer(ast.NodeVisitor):
                 self._symbol_table.has_ast_node_for_symbol(node.func.id):
             self._infer_function_call(node)
 
+    def visit_Lambda(self, node):
+        # Lambda is going to be a bit tricky because
+        # there's a new child namespace (via .get_children()),
+        # but it's not something that will show up in the
+        # current symbol table via .lookup().
+        # For now, we're going to ignore lambda expressions.
+        pass
+
     def _infer_function_call(self, node):
         # Here we're calling a function we haven't analyzed
         # yet.  We're first going to analyze the function.

--- a/tests/unit/test_analyzer.py
+++ b/tests/unit/test_analyzer.py
@@ -407,6 +407,16 @@ def test_map_string_literals_across_scopes():
     """) == {'s3': set(['list_buckets']), 'dynamodb': set(['list_tables'])}
 
 
+def test_can_handle_lambda_keyword():
+    assert aws_calls("""\
+        def foo(a):
+            return sorted(bar.values(),
+                          key=lambda x: x.baz[a - 1],
+                          reverse=True)
+        bar = {}
+        foo(12)
+    """) == {}
+
 #def test_tuple_assignment():
 #    assert aws_calls("""\
 #        import boto3


### PR DESCRIPTION
Fixes #74.

My plan is to fully support lambda functions, but until that time, the analyzer should not crash when encountering a lambda expression.