### PR TITLE
Print original stacktrace on debug errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,3 +18,5 @@ Next Release
   (`#79 <https://github.com/awslabs/chalice/issues/79>`__)
 * Ignore lambda expressions in policy analyzer
   (`#74 <https://github.com/awslabs/chalice/issues/74>`__)
+* Print original error traceback in debug mode
+  (`#50 <https://github.com/awslabs/chalice/issues/50>`__)

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -190,11 +190,11 @@ class Chalice(object):
                                        event['stage-variables'])
         try:
             response = view_function(*function_args)
-        except Exception as e:
+        except Exception:
             if self.debug:
                 # If the user has turned on debug mode,
                 # we'll let the original exception propogate so
                 # they get more information about what went wrong.
-                raise e
+                raise
             raise ChaliceViewError("An internal server error occurred.")
         return response


### PR DESCRIPTION
Before:

```
{
    "errorMessage": "Raising an exception!",
    "errorType": "RuntimeError",
    "stackTrace": [
        [
            "/var/task/chalice/__init__.py",
            198,
            "__call__",
            "raise e"
        ]
    ]
}
```

After:
```
{
    "errorMessage": "Raising an exception!",
    "errorType": "RuntimeError",
    "stackTrace": [
        [
            "/var/task/chalice/__init__.py",
            192,
            "__call__",
            "response = view_function(*function_args)"
        ],
        [
            "/var/task/app.py",
            9,
            "index",
            "return a()"
        ],
        [
            "/var/task/app.py",
            12,
            "a",
            "return b()"
        ],
        [
            "/var/task/app.py",
            15,
            "b",
            "raise RuntimeError(\"Raising an exception!\")"
        ]
    ]
}
```

This also shows up in `chalice logs`:

```
2016-08-01 16:14:06.897000 dcd6c3 Raising an exception!: RuntimeError
Traceback (most recent call last):
  File "/var/task/chalice/__init__.py", line 192, in __call__
    response = view_function(*function_args)
  File "/var/task/app.py", line 9, in index
    return a()
  File "/var/task/app.py", line 12, in a
    return b()
  File "/var/task/app.py", line 15, in b
    raise RuntimeError("Raising an exception!")
RuntimeError: Raising an exception!
```

Fixes #50.