### PR TITLE
Call write_config_to_disk for an existing lambda & example template fix

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -35,7 +35,7 @@ def index():
 #    # '/hello/james' -> {"hello": "james"}
 #    return {'hello': name}
 #
-# @app.route('/users/', methods=['POST'])
+# @app.route('/users', methods=['POST'])
 # def create_user():
 #     # This is the JSON body the user sent in their POST request.
 #     user_as_json = app.json_body

--- a/chalice/deployer.py
+++ b/chalice/deployer.py
@@ -254,7 +254,7 @@ class Deployer(object):
             function_arn = self._first_time_lambda_create(config)
             # Record the lambda_arn for later use.
             config['config']['lambda_arn'] = function_arn
-            self._write_config_to_disk(config)
+        self._write_config_to_disk(config)
         print "Lambda deploy done."
 
     def _update_lambda_function(self, config):


### PR DESCRIPTION
* Need to call `Deployer.write_config_to_disk` for an existing lambda for instance to update stage, might be used to update other information.
* App template had extra slash, that was causing:
`botocore.exceptions.ClientError: An error occurred (BadRequestException) when calling the CreateResource operation: Resource's path part must be specified`