### PR TITLE
Add policy mapping for ListObjectsV2

### DIFF
--- a/chalice/policies.json
+++ b/chalice/policies.json
@@ -779,6 +779,7 @@
     "CompleteMultipartUpload": "s3:PutObject",
     "ListBuckets": "s3:ListAllMyBuckets",
     "ListObjects": "s3:ListBucket",
+    "ListObjectsV2": "s3:ListBucket",
     "ListAllMyBuckets": "s3:ListAllMyBuckets",
     "ListBucket": "s3:ListBucket",
     "ListBucketMultipartUploads": "s3:ListBucketMultipartUploads",


### PR DESCRIPTION
The S3 operation ListObjectsV2 is missing in the mapping to policies. This pull request adds mapping for ListObjectsV2.