### PR TITLE
add incoming content types to routes

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -67,7 +67,10 @@ class Request(object):
         self.uri_params = uri_params
         self.method = method
         #: The parsed JSON from the body.
-        self.json_body = body
+        if self.headers.get('Content-Type', '') == "application/json":
+            self.json_body = body
+        else:
+            self.json_body = None
         # This is the raw base64 body.
         # We'll only bother decoding this if the user
         # actually requests this via the `.raw_body` property.

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -97,7 +97,8 @@ class RouteEntry(object):
             methods,
             authorization_type=None,
             authorizer_id=None,
-            api_key_required=False):
+            api_key_required=False,
+            content_types=None):
         self.view_function = view_function
         self.view_name = view_name
         self.uri_pattern = path
@@ -108,6 +109,7 @@ class RouteEntry(object):
         #: A list of names to extract from path:
         #: e.g, '/foo/{bar}/{baz}/qux -> ['bar', 'baz']
         self.view_args = self._parse_view_args()
+        self.content_types = content_types
 
     def _parse_view_args(self):
         if '{' not in self.uri_pattern:
@@ -146,6 +148,7 @@ class Chalice(object):
         authorization_type = kwargs.get('authorization_type', None)
         authorizer_id = kwargs.get('authorizer_id', None)
         api_key_required = kwargs.get('api_key_required', None)
+        content_types = kwargs.get('content_types', None)
 
         if path in self.routes:
             raise ValueError(
@@ -158,7 +161,9 @@ class Chalice(object):
             methods,
             authorization_type,
             authorizer_id,
-            api_key_required)
+            api_key_required,
+            content_types,
+        )
 
     def __call__(self, event, context):
         # This is what's invoked via lambda.

--- a/chalice/deployer.py
+++ b/chalice/deployer.py
@@ -615,6 +615,8 @@ class APIGatewayResourceCreator(object):
             except AttributeError:
                 pass
 
+        route_entry = node['route_entry']
+        content_types = route_entry.content_types or ['application/json']
         c.put_method(**put_method_cfg)
         c.put_integration(
             restApiId=self.rest_api_id,
@@ -627,7 +629,7 @@ class APIGatewayResourceCreator(object):
             # is not application/json.
             passthroughBehavior="NEVER",
             requestTemplates={
-                'application/json': FULL_PASSTHROUGH,
+                key: FULL_PASSTHROUGH for key in content_types
             },
             uri=self._lambda_uri()
         )


### PR DESCRIPTION
this is my proof of concept for adding the ability to accept content-types other than application/json, see #96 .

The app.route decorator would look something like:
```
@app.route(
    '/',
    methods=['POST', 'GET'],
    content_types=['application/json', 'application/x-www-form-urlencoded']
)
def index():
    ...
```