### PR TITLE
Adding details about the other errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -374,6 +374,13 @@ There's a few additional exceptions you can raise from your python code::
 * ChaliceViewError - return a status code of 500
 * NotFoundError - return a status code of 404
 
+In the ``chalice.app`` module, the following errors are also available
+* UnauthorizedError - return a status code of 401
+* ForbiddenError - return a status code of 403
+* ConflictError - return a status code of 409
+* TooManyRequestsError - return a status code of 429
+
+
 Tutorial: Additional Routing
 ============================
 

--- a/README.rst
+++ b/README.rst
@@ -374,7 +374,8 @@ There's a few additional exceptions you can raise from your python code::
 * ChaliceViewError - return a status code of 500
 * NotFoundError - return a status code of 404
 
-In the ``chalice.app`` module, the following errors are also available
+In the ``chalice.app`` module, the following errors are also available::
+
 * UnauthorizedError - return a status code of 401
 * ForbiddenError - return a status code of 403
 * ConflictError - return a status code of 409


### PR DESCRIPTION
This adds details for other Error types found in the chalice.app module.

- UnauthorizedError
- ForbiddenError
- ConflictError
- TooManyRequestsError

Signed-off-by: Jason Myers <jason@jasonamyers.com>