### PR TITLE
Include app.py's sibling modules in deployment package

### DIFF
--- a/chalice/deployer.py
+++ b/chalice/deployer.py
@@ -785,8 +785,10 @@ class LambdaDeploymentPackager(object):
             chalice_init = chalice_init[:-1]
         zip.write(chalice_router, 'chalice/__init__.py')
 
-        zip.write(os.path.join(project_dir, 'app.py'),
-                  'app.py')
+        # TODO: add sub modules
+        py_files = filter(lambda x: x.endswith('.py'), os.listdir(project_dir))
+        for f in py_files:
+            zip.write(os.path.join(project_dir, f), f)
 
     def _hash_requirements_file(self, filename):
         # type: (str) -> str


### PR DESCRIPTION
Here's a super-duper simplistic cut at addressing https://github.com/awslabs/chalice/issues/21 (possible duplicate of: https://github.com/awslabs/chalice/pull/56). It'll include all sibling `.py` files to `app.py`. Let me know what you think about this approach. If you like it, I'll clean it up with docs/testing.
