### PR TITLE
Always let chalice view errors propagate

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ Next Release (TBD)
 
 * Add support for input content types besides ``application/json``
   (`#96 <https://github.com/awslabs/chalice/issues/96>`__)
+* Allow ``ChaliceViewErrors`` to propagate, so that API Gateway
+  can properly map HTTP status codes in non debug mode
+  (`#113 <https://github.com/awslabs/chalice/issues/113>`__)
 
 
 0.1.0

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -194,6 +194,10 @@ class Chalice(object):
                                        event['stage-variables'])
         try:
             response = view_function(*function_args)
+        except ChaliceViewError:
+            # Any chalice view error should propagate.  These
+            # get mapped to various HTTP status codes in API Gateway.
+            raise
         except Exception:
             if self.debug:
                 # If the user has turned on debug mode,


### PR DESCRIPTION
These need to propagate because API gateway will map these
to appropriate HTTP status codes.

This was previously only happening in debug mode.

Fixes #113.