### PR TITLE
Export the view exceptions into chalice package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -371,15 +371,19 @@ a ``BadRequestError`` from your view function, the framework will return an
 HTTP status code of 400 along with a JSON body with a ``Code`` and ``Message``.
 There are a few additional exceptions you can raise from your python code::
 
-* ChaliceViewError - return a status code of 500
-* NotFoundError - return a status code of 404
-
-In the ``chalice.app`` module, the following errors are also available::
-
+* BadRequestError - return a status code of 400
 * UnauthorizedError - return a status code of 401
 * ForbiddenError - return a status code of 403
+* NotFoundError - return a status code of 404
 * ConflictError - return a status code of 409
 * TooManyRequestsError - return a status code of 429
+* ChaliceViewError - return a status code of 500
+
+You can import these directly from the ``chalice`` package:
+
+.. code-block:: python
+
+    from chalice import UnauthorizedError
 
 
 Tutorial: Additional Routing

--- a/chalice/__init__.py
+++ b/chalice/__init__.py
@@ -1,5 +1,8 @@
 from chalice.app import Chalice
-from chalice.app import ChaliceViewError, BadRequestError, NotFoundError
+from chalice.app import (
+    ChaliceViewError, BadRequestError, UnauthorizedError, ForbiddenError,
+    NotFoundError, ConflictError, TooManyRequestsError
+)
 
 
 __version__ = '0.1.0'


### PR DESCRIPTION
There was an inconsistency where you had to use
`chalice.app` to pull in certain exceptions, which was never
the intent.  These are all available in the top level
``chalice`` package now.

Updated docs accordingly.  The old way still works, but the
preferred way is just `from chalice import ForbiddenError`.