### PR TITLE
Run type checks as part of the travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: python
-python:
-  - "2.7"
 sudo: false
-env:
-  - TEST_TYPE=test
-  - TEST_TYPE=check
 matrix:
   include:
   - python: "3.5"
-  - env: TEST_TYPE=typecheck
+    env: TEST_TYPE=typecheck
+  - python: "2.7"
+    env: TEST_TYPE=test
+  - python: "2.7"
+    env: TEST_TYPE=check
 install:
   - pip install -e .
   - travis_retry pip install -r requirements-dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: python
 python:
   - "2.7"
 sudo: false
+env:
+  - TEST_TYPE=test
+  - TEST_TYPE=check
 install:
   - pip install -e .
   - travis_retry pip install -r requirements-dev.txt
 script:
-  - make test
-  - make check
+  - make $TEST_TYPE

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,13 @@ sudo: false
 env:
   - TEST_TYPE=test
   - TEST_TYPE=check
+matrix:
+  include:
+  - python: "3.5"
+  - env: TEST_TYPE=typecheck
 install:
   - pip install -e .
   - travis_retry pip install -r requirements-dev.txt
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then pip install mypy-lang==0.4.4; fi
 script:
   - make $TEST_TYPE

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,17 @@ test:
 	py.test -v $(TESTS)
 
 typecheck:
-	mypy --py2 --silent-import -p chalice
+	mypy --py2 --silent-import -p chalice --strict-optional
+	# Set of modules that will require type hints for all methods.
+	# The eventual goal is to just --disallow-untyped-defs for
+	# the entire chalice package, but for now as modules have complete
+	# type definitions, the list below should be updated.
+	mypy --py2 --silent-import -p chalice.deployer --disallow-untyped-defs --strict-optional
+	mypy --py2 --silent-import -p chalice.policy --disallow-untyped-defs --strict-optional
+	mypy --py2 --silent-import -p chalice.prompts --disallow-untyped-defs --strict-optional
+	mypy --py2 --silent-import -p chalice.awsclient --disallow-untyped-defs --strict-optional
+	mypy --py2 --silent-import -p chalice.prompts --disallow-untyped-defs --strict-optional
+	mypy --py2 --silent-import -p chalice.logs --disallow-untyped-defs --strict-optional
 
 coverage:
 	py.test --cov chalice --cov-report term-missing $(TESTS)


### PR DESCRIPTION
Starts enforcing that mypy is run for every build.  Also ensure that once a module is completely typed, that `--disallow-untyped-defs` is added such that all new changes will need type hints.