### PR TITLE
Prevent trailing whitespace in policy.json.

### DIFF
--- a/chalice/deployer.py
+++ b/chalice/deployer.py
@@ -656,7 +656,7 @@ class LambdaDeployer(object):
         policy_file = os.path.join(config.project_dir,
                                    '.chalice', 'policy.json')
         with open(policy_file, 'w') as f:
-            f.write(json.dumps(policy, indent=2))
+            f.write(json.dumps(policy, indent=2, separators=(',', ': ')))
 
     def _first_time_lambda_create(self, config):
         # type: (Config) -> str


### PR DESCRIPTION
Python's `json.dumps` function places trailing whitespace on some lines when
`indent` is specified. Among other things, this can cause spurious diffs
when a correctly formatted, non-autogen policy is processed for deployment.

Adding an appropriate `seperators` argument suppresses the trailing
whitespace.

REF: https://docs.python.org/2.7/library/json.html