### PR TITLE
Add integration smoke test

### DIFF
--- a/chalice/config.py
+++ b/chalice/config.py
@@ -6,9 +6,15 @@ class Config(object):
                  default_params=None):
         #: Params that a user provided explicitly,
         #: typically via the command line.
+        if user_provided_params is None:
+            user_provided_params = {}
         self._user_provided_params = user_provided_params
         #: The json.loads() from .chalice/config.json
+        if config_from_disk is None:
+            config_from_disk = {}
         self._config_from_disk = config_from_disk
+        if default_params is None:
+            default_params = {}
         self._default_params = default_params
 
     @classmethod

--- a/chalice/deployer.py
+++ b/chalice/deployer.py
@@ -646,6 +646,7 @@ class LambdaDeployer(object):
         policy_file = os.path.join(config.project_dir,
                                    '.chalice', 'policy.json')
         if not os.path.isfile(policy_file):
+            # TODO: Should return at least {'Statement': []}.
             return {}
         with open(policy_file, 'r') as f:
             return json.loads(f.read())

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
-pytest==2.9.2
+pytest==3.0.2
 py==1.4.31
 pygments==2.1.3
 mock==2.0.0
+requests==2.11.1

--- a/tests/integration/test_features.py
+++ b/tests/integration/test_features.py
@@ -1,0 +1,157 @@
+import pytest
+import os
+import requests
+import json
+import botocore.session
+import shutil
+
+from chalice import deployer
+from chalice.cli import load_chalice_app
+from chalice.config import Config
+
+CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_DIR = os.path.join(CURRENT_DIR, 'testapp')
+CHALICE_DIR = os.path.join(PROJECT_DIR, '.chalice')
+
+
+class SmokeTestApplication(object):
+    def __init__(self, url, rest_api_id, region_name, name):
+        if url.endswith('/'):
+            url = url[:-1]
+        self.url = url
+        self.rest_api_id = rest_api_id
+        self.region_name = region_name
+        self.name = name
+
+    def get_json(self, url):
+        if not url.startswith('/'):
+            url = '/' + url
+        response = requests.get(self.url + url)
+        response.raise_for_status()
+        return response.json()
+
+
+@pytest.fixture(scope='module')
+def smoke_test_app():
+    application = _deploy_app()
+    yield application
+    _delete_app(application)
+
+
+def _deploy_app():
+    if not os.path.isdir(CHALICE_DIR):
+        os.makedirs(CHALICE_DIR)
+    session = botocore.session.get_session()
+    config = Config.create(
+        project_dir=PROJECT_DIR,
+        app_name='smoketestapp',
+        stage_name='dev',
+        autogen_policy=True,
+        chalice_app=load_chalice_app(PROJECT_DIR),
+    )
+    d = deployer.create_default_deployer(session=session)
+    rest_api_id, region_name, stage = d.deploy(config)
+    url = (
+        "https://{api_id}.execute-api.{region}.amazonaws.com/{stage}/".format(
+            api_id=rest_api_id, region=region_name, stage=stage))
+    application = SmokeTestApplication(url, rest_api_id, region_name, 'smoketestapp')
+    return application
+
+
+def _delete_app(application):
+    s = botocore.session.get_session()
+    lambda_client = s.create_client('lambda')
+    lambda_client.delete_function(FunctionName=application.name)
+
+    iam = s.create_client('iam')
+    policies = iam.list_role_policies(RoleName=application.name)
+    for name in policies['PolicyNames']:
+        iam.delete_role_policy(RoleName=application.name, PolicyName=name)
+    iam.delete_role(RoleName=application.name)
+
+    apig = s.create_client('apigateway')
+    apig.delete_rest_api(restApiId=application.rest_api_id)
+    chalice_dir = os.path.join(PROJECT_DIR, '.chalice')
+    shutil.rmtree(chalice_dir)
+    os.makedirs(chalice_dir)
+
+
+def test_returns_simple_response(smoke_test_app):
+    assert smoke_test_app.get_json('/') == {'hello': 'world'}
+
+
+def test_can_have_nested_routes(smoke_test_app):
+    assert smoke_test_app.get_json('/a/b/c/d/e/f/g') == {'nested': True}
+
+
+def test_supports_path_params(smoke_test_app):
+    assert smoke_test_app.get_json('/path/foo') == {'path': 'foo'}
+    assert smoke_test_app.get_json('/path/bar') == {'path': 'bar'}
+
+
+def test_supports_post(smoke_test_app):
+    app_url = smoke_test_app.url
+    response = requests.post(app_url + '/post')
+    response.raise_for_status()
+    assert response.json() == {'success': True}
+    with pytest.raises(requests.HTTPError):
+        # Only POST is supported.
+        response = requests.get(app_url + '/post')
+        response.raise_for_status()
+
+
+def test_supports_put(smoke_test_app):
+    app_url = smoke_test_app.url
+    response = requests.put(app_url + '/put')
+    response.raise_for_status()
+    assert response.json() == {'success': True}
+    with pytest.raises(requests.HTTPError):
+        # Only PUT is supported.
+        response = requests.get(app_url + '/put')
+        response.raise_for_status()
+
+
+def test_can_read_json_body_on_post(smoke_test_app):
+    app_url = smoke_test_app.url
+    response = requests.post(
+        app_url + '/jsonpost', data=json.dumps({'hello': 'world'}),
+        headers={'Content-Type': 'application/json'})
+    response.raise_for_status()
+    assert response.json() == {'json_body': {'hello': 'world'}}
+
+
+def test_can_raise_bad_request(smoke_test_app):
+    response = requests.get(smoke_test_app.url + '/badrequest')
+    assert response.status_code == 400
+    assert response.json()['Code'] == 'BadRequestError'
+    assert response.json()['Message'] == 'Bad request.'
+
+
+def test_can_raise_bad_request(smoke_test_app):
+    response = requests.get(smoke_test_app.url + '/notfound')
+    assert response.status_code == 404
+    assert response.json()['Code'] == 'NotFoundError'
+
+
+def test_unexpected_error_raises_500_in_prod_mode(smoke_test_app):
+    response = requests.get(smoke_test_app.url + '/arbitrary-error')
+    assert response.status_code == 500
+    assert response.json()['Code'] == 'ChaliceViewError'
+    assert 'internal server error' in response.json()['Message']
+
+
+def test_can_route_multiple_methods_in_one_view(smoke_test_app):
+    response = requests.get(smoke_test_app.url + '/multimethod')
+    response.raise_for_status()
+    assert response.json()['method'] == 'GET'
+
+    response = requests.post(smoke_test_app.url + '/multimethod')
+    response.raise_for_status()
+    assert response.json()['method'] == 'POST'
+
+
+def test_form_encoded_content_type(smoke_test_app):
+    response = requests.post(smoke_test_app.url + '/formencoded',
+                             data={'foo': 'bar'})
+    response.raise_for_status()
+    assert response.json() == {'parsed': {'foo': ['bar']}}

--- a/tests/integration/testapp/app.py
+++ b/tests/integration/testapp/app.py
@@ -1,0 +1,68 @@
+from chalice import Chalice, BadRequestError, NotFoundError
+
+import  urlparse
+# This is a test app that is used by integration tests.
+# This app exercises all the major features of chalice
+# and helps prevent regressions.
+
+app = Chalice(app_name='smoketestapp')
+
+
+@app.route('/')
+def index():
+    return {'hello': 'world'}
+
+
+@app.route('/a/b/c/d/e/f/g')
+def nested_route():
+    return {'nested': True}
+
+
+@app.route('/path/{name}')
+def supports_path_params(name):
+    return {'path': name}
+
+
+@app.route('/post', methods=['POST'])
+def supports_only_post():
+    return {'success': True}
+
+
+@app.route('/put', methods=['PUT'])
+def supports_only_put():
+    return {'success': True}
+
+
+@app.route('/jsonpost', methods=['POST'])
+def supports_post_body_as_json():
+    json_body = app.current_request.json_body
+    return {'json_body': json_body}
+
+
+@app.route('/multimethod', methods=['GET', 'POST'])
+def multiple_methods():
+    return {'method': app.current_request.method}
+
+
+@app.route('/badrequest')
+def bad_request_error():
+    raise BadRequestError("Bad request.")
+
+
+@app.route('/notfound')
+def not_found_error():
+    raise NotFoundError("Not found")
+
+
+@app.route('/arbitrary-error')
+def raise_arbitrary_error():
+    raise TypeError("Uncaught exception")
+
+
+@app.route('/formencoded', methods=['POST'],
+           content_types=['application/x-www-form-urlencoded'])
+def form_encoded():
+    parsed = urlparse.parse_qs(app.current_request.raw_body)
+    return {
+        'parsed': parsed
+    }


### PR DESCRIPTION
This test will actually deploy a chalice app and make HTTP
requests to ensure the expected behavior.

This also makes it easier to test larger scale refactorings to ensure
existing behavior is not broken.

As part of this change I had to bump the pytest version to pull
in support for "yielding" from fixtures.