### PR TITLE
Extract APIG method creation into separate class

### DIFF
--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -169,6 +169,34 @@ class TypedAWSClient(object):
             stageName=stage_name,
         )
 
+    def create_rest_resource(self, rest_api_id, parent_id, path_part):
+        # type: (str, str, str) -> Dict[str, Any]
+        client = self._client('apigateway')
+        response = client.create_resource(
+            restApiId=rest_api_id,
+            parentId=parent_id,
+            pathPart=path_part,
+        )
+        return response
+
+    def add_permission_for_apigateway(self, function_name, region_name,
+                                      account_id, rest_api_id, random_id):
+        # type: (str, str, str, str, str) -> None
+        """Authorize API gateway to invoke a lambda function."""
+        client = self._client('lambda')
+        client.add_permission(
+            Action='lambda:InvokeFunction',
+            FunctionName=function_name,
+            StatementId=random_id,
+            Principal='apigateway.amazonaws.com',
+            SourceArn=('arn:aws:execute-api:{region_name}:{account_id}'
+                       ':{rest_api_id}/*').format(
+                region_name=region_name,
+                # Assuming same account id for lambda function and API gateway.
+                account_id=account_id,
+                rest_api_id=rest_api_id)
+        )
+
     @property
     def region_name(self):
         # type: () -> str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,92 @@
+import botocore.session
+from botocore.stub import Stubber
+from pytest import fixture
+
+
+class StubbedSession(botocore.session.Session):
+    def __init__(self, *args, **kwargs):
+        super(StubbedSession, self).__init__(*args, **kwargs)
+        self._cached_clients = {}
+        self._client_stubs = {}
+
+    def create_client(self, service_name, *args, **kwargs):
+        if service_name not in self._cached_clients:
+            client = self._create_stubbed_client(service_name, *args, **kwargs)
+            self._cached_clients[service_name] = client
+        return self._cached_clients[service_name]
+
+    def _create_stubbed_client(self, service_name, *args, **kwargs):
+        client = super(StubbedSession, self).create_client(
+            service_name, *args, **kwargs)
+        stubber = StubBuilder(Stubber(client))
+        self._client_stubs[service_name] = stubber
+        return client
+
+    def stub(self, service_name):
+        if service_name not in self._client_stubs:
+            self.create_client(service_name)
+        return self._client_stubs[service_name]
+
+    def activate_stubs(self):
+        for stub in self._client_stubs.values():
+            stub.activate()
+
+    def verify_stubs(self):
+        for stub in self._client_stubs.values():
+            stub.assert_no_pending_responses()
+
+
+class StubBuilder(object):
+    def __init__(self, stub):
+        self.stub = stub
+        self.activated = False
+        self.pending_args = {}
+
+    def __getattr__(self, name):
+        if self.activated:
+            # I want to be strict here to guide common test behavior.
+            # This helps encourage the "record" "replay" "verify"
+            # idiom in traditional mock frameworks.
+            raise RuntimeError("Stub has already been activated: %s, "
+                               "you must set up your stub calls before "
+                               "calling .activate()" % self.stub)
+        if not name.startswith('_'):
+            # Assume it's an API call.
+            self.pending_args['operation_name'] = name
+            return self
+
+    def assert_no_pending_responses(self):
+        self.stub.assert_no_pending_responses()
+
+    def activate(self):
+        self.activated = True
+        self.stub.activate()
+
+    def returns(self, response):
+        self.pending_args['service_response'] = response
+        # returns() is essentially our "build()" method and triggers
+        # creations of a stub response creation.
+        p = self.pending_args
+        self.stub.add_response(p['operation_name'],
+                               expected_params=p['expected_params'],
+                               service_response=p['service_response'])
+        # And reset the pending_args for the next stub creation.
+        self.pending_args = {}
+
+    def raises_error(self, error_code, message):
+        p = self.pending_args
+        self.stub.add_client_error(p['operation_name'],
+                                   service_error_code=error_code,
+                                   service_message=message)
+        # Reset pending args for next expectation.
+        self.pending_args = {}
+
+    def __call__(self, **kwargs):
+        self.pending_args['expected_params'] = kwargs
+        return self
+
+
+@fixture
+def stubbed_session():
+    s = StubbedSession()
+    return s

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,0 +1,14 @@
+from pytest import fixture
+
+
+@fixture(autouse=True)
+def set_region(monkeypatch):
+    monkeypatch.setenv('AWS_DEFAULT_REGION', 'us-west-2')
+    monkeypatch.setenv('AWS_ACCESS_KEY_ID', 'foo')
+    monkeypatch.setenv('AWS_SECRET_ACCESS_KEY', 'bar')
+    monkeypatch.delenv('AWS_PROFILE', raising=False)
+    # Ensure that the existing ~/.aws/{config,credentials} file
+    # don't influence test results.
+    monkeypatch.setenv('AWS_CONFIG_FILE', '/tmp/asdfasdfaf/does/not/exist')
+    monkeypatch.setenv('AWS_SHARED_CREDENTIALS_FILE',
+                       '/tmp/asdfasdfaf/does/not/exist2')

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -2,115 +2,11 @@ import json
 import datetime
 import time
 
-from pytest import fixture
 import pytest
 import mock
-import botocore.session
-from botocore.stub import Stubber
+import botocore.exceptions
 
 from chalice.awsclient import TypedAWSClient
-
-
-class StubbedSession(botocore.session.Session):
-    def __init__(self, *args, **kwargs):
-        super(StubbedSession, self).__init__(*args, **kwargs)
-        self._cached_clients = {}
-        self._client_stubs = {}
-
-    def create_client(self, service_name, *args, **kwargs):
-        if service_name not in self._cached_clients:
-            client = self._create_stubbed_client(service_name, *args, **kwargs)
-            self._cached_clients[service_name] = client
-        return self._cached_clients[service_name]
-
-    def _create_stubbed_client(self, service_name, *args, **kwargs):
-        client = super(StubbedSession, self).create_client(
-            service_name, *args, **kwargs)
-        stubber = StubBuilder(Stubber(client))
-        self._client_stubs[service_name] = stubber
-        return client
-
-    def stub(self, service_name):
-        if service_name not in self._client_stubs:
-            self.create_client(service_name)
-        return self._client_stubs[service_name]
-
-    def activate_stubs(self):
-        for stub in self._client_stubs.values():
-            stub.activate()
-
-    def verify_stubs(self):
-        for stub in self._client_stubs.values():
-            stub.assert_no_pending_responses()
-
-
-class StubBuilder(object):
-    def __init__(self, stub):
-        self.stub = stub
-        self.activated = False
-        self.pending_args = {}
-
-    def __getattr__(self, name):
-        if self.activated:
-            # I want to be strict here to guide common test behavior.
-            # This helps encourage the "record" "replay" "verify"
-            # idiom in traditional mock frameworks.
-            raise RuntimeError("Stub has already been activated: %s, "
-                               "you must set up your stub calls before "
-                               "calling .activate()" % self.stub)
-        if not name.startswith('_'):
-            # Assume it's an API call.
-            self.pending_args['operation_name'] = name
-            return self
-
-    def assert_no_pending_responses(self):
-        self.stub.assert_no_pending_responses()
-
-    def activate(self):
-        self.activated = True
-        self.stub.activate()
-
-    def returns(self, response):
-        self.pending_args['service_response'] = response
-        # returns() is essentially our "build()" method and triggers
-        # creations of a stub response creation.
-        p = self.pending_args
-        self.stub.add_response(p['operation_name'],
-                               expected_params=p['expected_params'],
-                               service_response=p['service_response'])
-        # And reset the pending_args for the next stub creation.
-        self.pending_args = {}
-
-    def raises_error(self, error_code, message):
-        p = self.pending_args
-        self.stub.add_client_error(p['operation_name'],
-                                   service_error_code=error_code,
-                                   service_message=message)
-        # Reset pending args for next expectation.
-        self.pending_args = {}
-
-    def __call__(self, **kwargs):
-        self.pending_args['expected_params'] = kwargs
-        return self
-
-
-@fixture
-def stubbed_session():
-    s = StubbedSession()
-    return s
-
-
-@fixture(autouse=True)
-def set_region(monkeypatch):
-    monkeypatch.setenv('AWS_DEFAULT_REGION', 'us-west-2')
-    monkeypatch.setenv('AWS_ACCESS_KEY_ID', 'foo')
-    monkeypatch.setenv('AWS_SECRET_ACCESS_KEY', 'bar')
-    monkeypatch.delenv('AWS_PROFILE', raising=False)
-    # Ensure that the existing ~/.aws/{config,credentials} file
-    # don't influence test results.
-    monkeypatch.setenv('AWS_CONFIG_FILE', '/tmp/asdfasdfaf/does/not/exist')
-    monkeypatch.setenv('AWS_SHARED_CREDENTIALS_FILE',
-                       '/tmp/asdfasdfaf/does/not/exist2')
 
 
 def test_region_name_is_exposed(stubbed_session):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,14 @@
+from pytest import fixture
+
+
+@fixture(autouse=True)
+def set_region(monkeypatch):
+    monkeypatch.setenv('AWS_DEFAULT_REGION', 'us-west-2')
+    monkeypatch.setenv('AWS_ACCESS_KEY_ID', 'foo')
+    monkeypatch.setenv('AWS_SECRET_ACCESS_KEY', 'bar')
+    monkeypatch.delenv('AWS_PROFILE', raising=False)
+    # Ensure that the existing ~/.aws/{config,credentials} file
+    # don't influence test results.
+    monkeypatch.setenv('AWS_CONFIG_FILE', '/tmp/asdfasdfaf/does/not/exist')
+    monkeypatch.setenv('AWS_SHARED_CREDENTIALS_FILE',
+                       '/tmp/asdfasdfaf/does/not/exist2')


### PR DESCRIPTION
This is a refactoring that separates the logic for creating
an API gateway method (request method, integration request,
integration response, method response) into a separate class.

With the introduction of CORS support, these calls are no longer
unconditional calls.  This is going to grow even more so in
the future when CORSConfig is introduced along with other optional
values.

By separating this into a separate class, this also gives us the
ability to have much more granular testing when creating the
various methods/integrations, which has the most involved API calls.

As part of this change, I also switched over the
APIGatewayResourceCreator to only use the typed aws client.
This should also make this class easier to test now without requiring
the botocore stubber.