### PR TITLE
Don't crash policy gen on dict comp

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Next Release (TBD)
   (`#133 <https://github.com/awslabs/chalice/pull/133>`__)
 * Only add API gateway permissions if needed
   (`#48 <https://github.com/awslabs/chalice/issues/48>`__)
+* Fix error when dict comprehension is encountered during policy generation
+  (`#131 <https://github.com/awslabs/chalice/issues/131>`__)
 
 
 0.2.0

--- a/chalice/analyzer.py
+++ b/chalice/analyzer.py
@@ -423,6 +423,12 @@ class SymbolTableTypeInfer(ast.NodeVisitor):
         # traverse into the class body for now.
         return
 
+    def visit_DictComp(self, node):
+        # Not implemented yet.  This creates a new scope,
+        # so we'd need to treat this similar to how we treat
+        # functions.
+        pass
+
     def visit_Return(self, node):
         self.generic_visit(node)
         inferred_type = getattr(node.value, 'inferred_type', None)

--- a/tests/unit/test_analyzer.py
+++ b/tests/unit/test_analyzer.py
@@ -417,6 +417,22 @@ def test_can_handle_lambda_keyword():
         foo(12)
     """) == {}
 
+
+def test_dict_comp_with_no_client_calls():
+    assert aws_calls("""\
+        import boto3
+        foo = {i: i for i in range(10)}
+    """) == {}
+
+
+#def test_can_handle_dict_comp():
+#    assert aws_calls("""\
+#        import boto3
+#        ddb = boto3.client('dynamodb')
+#        tables = {t: t for t in ddb.list_tables()}
+#    """) == {'dynamodb': set(['list_tables'])}
+#
+#
 #def test_tuple_assignment():
 #    assert aws_calls("""\
 #        import boto3


### PR DESCRIPTION
For now we skip traversal into a dict comp.
In the future, we should treat this like a function
and traverse into the DictComp node looking for any
client calls, but the behavior until that feature
is implemented is to not crash.

Fixes #131.
