### PR TITLE
Add version and debug options to CLI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Next Release (TBD)
   (`#48 <https://github.com/awslabs/chalice/issues/48>`__)
 * Fix error when dict comprehension is encountered during policy generation
   (`#131 <https://github.com/awslabs/chalice/issues/131>`__)
+* Add ``--version`` and ``--debug`` options to the chalice CLI
 
 
 0.2.0

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -154,11 +154,6 @@ def deploy(ctx, project_dir, autogen_policy, profile, stage):
                                  "region value in our ~/.aws/config file.")
         e.exit_code = 2
         raise e
-    except Exception as e:
-        raise
-        e = click.ClickException("Error when deploying: %s" % e)
-        e.exit_code = 1
-        raise e
 
 
 @cli.command()

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -11,6 +11,7 @@ import botocore.exceptions
 import botocore.session
 
 from chalice import deployer
+from chalice import __version__ as chalice_version
 from chalice.logs import LogRetriever
 from chalice import prompts
 from chalice.config import Config
@@ -92,6 +93,7 @@ def load_chalice_app(project_dir):
 
 
 @click.group()
+@click.version_option(version=chalice_version, message='%(prog)s %(version)s')
 @click.pass_context
 def cli(ctx):
     pass

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -53,9 +53,12 @@ def index():
 """
 
 
-def create_botocore_session(profile=None):
+def create_botocore_session(profile=None, debug=False):
     session = botocore.session.Session(profile=profile)
     session.user_agent_extra = 'chalice/%s' % chalice_version
+    if debug:
+        session.set_debug_logger('')
+        inject_large_request_body_filter()
     return session
 
 
@@ -166,10 +169,7 @@ def deploy(ctx, project_dir, autogen_policy, profile, debug, stage):
     if profile:
         user_provided_params['profile'] = profile
     config = Config(user_provided_params, config_from_disk, default_params)
-    session = create_botocore_session(profile=config.profile)
-    if debug:
-        session.set_debug_logger('')
-        inject_large_request_body_filter()
+    session = create_botocore_session(profile=config.profile, debug=debug)
     d = deployer.create_default_deployer(session=session, prompter=click)
     try:
         d.deploy(config)

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -52,11 +52,16 @@ def index():
 """
 
 
+def create_botocore_session(profile=None):
+    session = botocore.session.Session(profile=profile)
+    session.user_agent_extra = 'chalice/%s' % chalice_version
+    return session
+
+
 def show_lambda_logs(config, max_entries, include_lambda_messages):
-    import botocore.session
     lambda_arn = config.lambda_arn
     profile = config.profile
-    client = botocore.session.Session(profile=profile).create_client('logs')
+    client = create_botocore_session(profile).create_client('logs')
     retriever = LogRetriever.create_from_arn(client, lambda_arn)
     events = retriever.retrieve_logs(
         include_lambda_messages=include_lambda_messages,
@@ -138,7 +143,7 @@ def deploy(ctx, project_dir, autogen_policy, profile, stage):
     if profile:
         user_provided_params['profile'] = profile
     config = Config(user_provided_params, config_from_disk, default_params)
-    session = botocore.session.Session(profile=config.profile)
+    session = create_botocore_session(profile=config.profile)
     d = deployer.create_default_deployer(session=session, prompter=click)
     try:
         d.deploy(config)


### PR DESCRIPTION
This should make it easier to troubleshoot issues by using `--debug`.  I had to add a filter so we don't see the base64 zipfile contents when creating/uploading the lambda function.