### PR TITLE
make RouteEntry._parse_view_args to respect greedy path variables

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -9,7 +9,7 @@ from collections import Mapping
 # startup overhead.
 
 
-_PARAMS = re.compile('{\w+}')
+_PARAMS = re.compile('{(\w+)\+?}')
 
 
 class ChaliceError(Exception):
@@ -138,9 +138,7 @@ class RouteEntry(object):
     def _parse_view_args(self):
         if '{' not in self.uri_pattern:
             return []
-        # The [1:-1] slice is to remove the braces
-        # e.g {foobar} -> foobar
-        results = [r[1:-1] for r in _PARAMS.findall(self.uri_pattern)]
+        results = _PARAMS.findall(self.uri_pattern)
         return results
 
     def __eq__(self, other):


### PR DESCRIPTION
The is a relatively new feature described [here](http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-set-up-simple-proxy.html): In addition to `/some/path/{tail}` route format there may be `/some/path/{tail+}` resource declarations in API Gateway now. 
And this short patch teaches `Chalice` how to deal with them.
