### PR TITLE
Raise TypeError when unknown kwargs are provided to route()

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -162,17 +162,20 @@ class Chalice(object):
         return _register_view
 
     def _add_route(self, path, view_func, **kwargs):
-        name = kwargs.get('name', view_func.__name__)
-        methods = kwargs.get('methods', ['GET'])
-        authorization_type = kwargs.get('authorization_type', None)
-        authorizer_id = kwargs.get('authorizer_id', None)
-        api_key_required = kwargs.get('api_key_required', None)
-        content_types = kwargs.get('content_types', ['application/json'])
-        cors = kwargs.get('cors', False)
+        name = kwargs.pop('name', view_func.__name__)
+        methods = kwargs.pop('methods', ['GET'])
+        authorization_type = kwargs.pop('authorization_type', None)
+        authorizer_id = kwargs.pop('authorizer_id', None)
+        api_key_required = kwargs.pop('api_key_required', None)
+        content_types = kwargs.pop('content_types', ['application/json'])
+        cors = kwargs.pop('cors', False)
         if not isinstance(content_types, list):
             raise ValueError('In view function "%s", the content_types '
                              'value must be a list, not %s: %s'
                              % (name, type(content_types), content_types))
+        if kwargs:
+            raise TypeError('TypeError: route() got unexpected keyword '
+                            'arguments: %s' % ', '.join(list(kwargs)))
 
         if path in self.routes:
             raise ValueError(

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -362,3 +362,10 @@ def test_case_insensitive_mapping():
     assert mapping.get('hEAdEr')
     assert 'hEAdEr' in mapping
     assert repr({'header': 'Value'}) in repr(mapping)
+
+
+def test_unknown_kwargs_raise_error(sample_app):
+    with pytest.raises(TypeError):
+        @sample_app.route('/foo', unknown_kwargs='foo')
+        def badkwargs():
+            pass


### PR DESCRIPTION
In an ideal world, I'd use the foo(*, kwarg1, kwargs2) of python3.
I'd still like to enforce that kwargs are used for any route
options, but we should validate that if you do typo an arg,
we raise an appropriate error.