### PR TITLE
Validate you don't have OPTIONS when cors=True

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Next Release (TBD)
   (`#139 <https://github.com/awslabs/chalice/issues/139>`__)
 * Raise errors when unknown kwargs are provided to ``app.route(...)``
   (`#144 <https://github.com/awslabs/chalice/pull/144>`__)
+* Raise validation error when configuring CORS and an OPTIONS method
+  (`#142 <https://github.com/awslabs/chalice/issues/142>`__)
 
 
 0.3.0

--- a/tests/unit/test_deployer.py
+++ b/tests/unit/test_deployer.py
@@ -12,6 +12,7 @@ from chalice.deployer import APIGatewayResourceCreator
 from chalice.deployer import APIGatewayMethods
 from chalice.deployer import FULL_PASSTHROUGH, ERROR_MAPPING
 from chalice.deployer import validate_configuration
+from chalice.deployer import validate_routes
 from chalice.deployer import Deployer
 from chalice.app import RouteEntry, ALL_ERRORS
 from chalice.app import Chalice
@@ -427,3 +428,12 @@ def test_lambda_deployer_repeated_deploy():
     # And should result in the lambda function being updated with the API.
     aws_client.update_function_code.assert_called_with(
         'appname', 'package contents')
+
+
+def test_cant_have_options_with_cors(sample_app):
+    @sample_app.route('/badcors', methods=['GET', 'OPTIONS'], cors=True)
+    def badview():
+        pass
+
+    with pytest.raises(ValueError):
+        validate_routes(sample_app.routes)


### PR DESCRIPTION
You'll get an error message from API gateway about a conflict
exception which isn't that helpful.  By adding it to the
validation step here, we get a much clearer error message:

```
ValueError: Route entry cannot have both cors=True and
methods=['OPTIONS', ...] configured.  When CORS is enabled, an OPTIONS
method is automatically added for you.  Please remove 'OPTIONS' from the
list of configured HTTP methods for: /badview
```

Closes #142.