### PR TITLE
Initial support for multi file apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ check:
 	# Basic error checking in test code
 	pyflakes tests/unit/ tests/functional/
 	##### DOC8 ######
-	# Correct rst formatting for docstrings
+	# Correct rst formatting for documentation
 	#
 	##
-	doc8 docs/source
+	doc8 docs/source --ignore-path docs/source/topics/multifile.rst
 	#
 	#
 	#

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -92,7 +92,6 @@ def load_project_config(project_dir):
 
 
 def load_chalice_app(project_dir):
-    app_py = os.path.join(project_dir, 'app.py')
     if project_dir not in sys.path:
         sys.path.append(project_dir)
     try:

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -7,6 +7,7 @@ import os
 import json
 import sys
 import logging
+import importlib
 
 import click
 import botocore.exceptions
@@ -94,18 +95,15 @@ def load_chalice_app(project_dir):
     app_py = os.path.join(project_dir, 'app.py')
     if project_dir not in sys.path:
         sys.path.append(project_dir)
-    with open(app_py) as f:
-        g = {}
-        contents = f.read()
-        try:
-            exec contents in g
-        except Exception as e:
-            exception = click.ClickException(
-                "Unable to import your app.py file: %s" % e
-            )
-            exception.exit_code = 2
-            raise exception
-        return g['app']
+    try:
+        app = importlib.import_module('app')
+    except Exception as e:
+        exception = click.ClickException(
+            "Unable to import your app.py file: %s" % e
+        )
+        exception.exit_code = 2
+        raise exception
+    return app.app
 
 
 def inject_large_request_body_filter():

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -5,6 +5,7 @@ Contains commands for deploying chalice.
 """
 import os
 import json
+import sys
 import logging
 
 import click
@@ -91,6 +92,8 @@ def load_project_config(project_dir):
 
 def load_chalice_app(project_dir):
     app_py = os.path.join(project_dir, 'app.py')
+    if project_dir not in sys.path:
+        sys.path.append(project_dir)
     with open(app_py) as f:
         g = {}
         contents = f.read()

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -56,6 +56,7 @@ Topics
 
    topics/routing
    topics/configfile
+   topics/multifile
 
 
 API Reference

--- a/docs/source/topics/multifile.rst
+++ b/docs/source/topics/multifile.rst
@@ -1,0 +1,91 @@
+Multifile Support
+=================
+
+The ``app.py`` file contains all of your view functions and route
+information, but you don't have to keep all of your application
+code in your ``app.py`` file.
+
+As your application grows, you may reach out a point where you'd
+prefer to structure your application in multiple files.
+You can create a ``chalicelib/`` directory, and anything
+in that directory is recursively included in the deployment
+package.  This means that you can have files besides just
+``.py`` files in ``chalicelib/``, including ``.json`` files
+for config, or any kind of binary assets.
+
+Let's take a look at a few examples.
+
+Consider the following app directory structure layout::
+
+    .
+    ├── app.py
+    ├── chalicelib
+    │   └── __init__.py
+    └── requirements.txt
+
+Where ``chalicelib/__init__.py`` contains:
+
+.. code-block:: python
+
+    MESSAGE = 'world'
+
+
+and the ``app.py`` file contains:
+
+.. code-block:: python
+    :linenos:
+    :emphasize-lines: 2
+
+    from chalice import Chalice
+    from chalicelib import MESSAGE
+
+    app = Chalice(app_name="multifile")
+
+    @app.route("/")
+    def index():
+        return {"hello": MESSAGE}
+
+
+Note in line 2 we're importing the ``MESSAGE`` variable from
+the ``chalicelib`` package, which is a top level directory
+in our project.  We've created a ``chalicelib/__init__.py``
+file which turns the ``chalicelib`` directory into a python
+package.
+
+We can also use this directory to store config data.   Consider
+this app structure layout::
+
+
+    .
+    ├── app.py
+    ├── chalicelib
+    │   └── config.json
+    └── requirements.txt
+
+
+With ``chalicelib/config.json`` containing::
+
+    {"message": "world"}
+
+
+In our ``app.py`` code, we can load and use our config file:
+
+.. code-block:: python
+    :linenos:
+
+    import os
+    import json
+
+    from chalice import Chalice
+
+    app = Chalice(app_name="multifile")
+
+    filename = os.path.join(
+        os.path.dirname(__file__), 'chalicelib', 'config.json')
+    with open(filename) as f:
+        config = json.load(f)
+
+    @app.route("/")
+    def index():
+        # We can access ``config`` here if we want. 
+        return {"hello": config['message']}

--- a/docs/source/topics/multifile.rst
+++ b/docs/source/topics/multifile.rst
@@ -87,5 +87,5 @@ In our ``app.py`` code, we can load and use our config file:
 
     @app.route("/")
     def index():
-        # We can access ``config`` here if we want. 
+        # We can access ``config`` here if we want.
         return {"hello": config['message']}

--- a/tests/functional/test_deployer.py
+++ b/tests/functional/test_deployer.py
@@ -1,3 +1,4 @@
+import os
 import zipfile
 from pytest import fixture
 
@@ -62,6 +63,20 @@ def test_can_inject_latest_app(tmpdir, chalice_deployer):
         assert contents == '# Test app NEW VERSION'
 
 
+def test_app_injection_still_compresses_file(tmpdir, chalice_deployer):
+    appdir = _create_app_structure(tmpdir)
+    appdir.join('app.py').write('# Test app v1')
+    name = chalice_deployer.create_deployment_package(str(appdir))
+    original_size = os.path.getsize(name)
+    appdir.join('app.py').write('# Test app v2')
+    chalice_deployer.inject_latest_app(name, str(appdir))
+    new_size = os.path.getsize(name)
+    # The new_size won't be exactly the same as the original,
+    # we just want to make sure it wasn't converted to
+    # ZIP_STORED.
+    assert abs(original_size - new_size) < 10
+
+
 def test_no_error_message_printed_on_empty_reqs_file(tmpdir,
                                                      chalice_deployer,
                                                      capfd):
@@ -78,6 +93,7 @@ def test_can_create_deployer_from_factory_function():
     d = deployer.create_default_deployer(session)
     assert isinstance(d, deployer.Deployer)
 
+
 def test_osutils_proxies_os_functions(tmpdir):
     appdir = _create_app_structure(tmpdir)
     appdir.join('app.py').write(b'hello')
@@ -92,3 +108,50 @@ def test_osutils_proxies_os_functions(tmpdir):
     # Removing again doesn't raise an error.
     osutils.remove_file(app_file)
     assert not osutils.file_exists(app_file)
+
+
+def test_includes_app_and_chalicelib_dir(tmpdir, chalice_deployer):
+    appdir = _create_app_structure(tmpdir)
+    # We're now also going to create additional files
+    chalicelib = appdir.mkdir('chalicelib')
+    appdir.join('chalicelib', '__init__.py').write('# Test package')
+    appdir.join('chalicelib', 'mymodule.py').write('# Test module')
+    appdir.join('chalicelib', 'config.json').write('{"test": "config"}')
+    # Should also include sub directories
+    subdir = chalicelib.mkdir('subdir')
+    subdir.join('submodule.py').write('# Test submodule')
+    subdir.join('subconfig.json').write('{"test": "subconfig"}')
+    name = chalice_deployer.create_deployment_package(str(appdir))
+    with zipfile.ZipFile(name) as f:
+        _assert_in_zip('chalicelib/__init__.py', '# Test package', f)
+        _assert_in_zip('chalicelib/mymodule.py', '# Test module', f)
+        _assert_in_zip('chalicelib/config.json', '{"test": "config"}', f)
+        _assert_in_zip('chalicelib/subdir/submodule.py',
+                       '# Test submodule', f)
+        _assert_in_zip('chalicelib/subdir/subconfig.json',
+                       '{"test": "subconfig"}', f)
+
+
+def _assert_in_zip(path, contents, zip):
+    allfiles = zip.namelist()
+    assert path in allfiles
+    assert zip.read(path) == contents
+
+
+def test_subsequent_deploy_replaces_chalicelib(tmpdir, chalice_deployer):
+    appdir = _create_app_structure(tmpdir)
+    chalicelib = appdir.mkdir('chalicelib')
+    appdir.join('chalicelib', '__init__.py').write('# Test package')
+    subdir = chalicelib.mkdir('subdir')
+    subdir.join('submodule.py').write('# Test submodule')
+
+    name = chalice_deployer.create_deployment_package(str(appdir))
+    subdir.join('submodule.py').write('# Test submodule v2')
+    appdir.join('chalicelib', '__init__.py').remove()
+    chalice_deployer.inject_latest_app(name, str(appdir))
+    with zipfile.ZipFile(name) as f:
+        _assert_in_zip('chalicelib/subdir/submodule.py',
+                       '# Test submodule v2', f)
+        # And chalicelib/__init__.py should no longer be
+        # in the zipfile because we deleted it in the appdir.
+        assert 'chalicelib/__init__.py' not in f.namelist()

--- a/tests/integration/test_features.py
+++ b/tests/integration/test_features.py
@@ -174,3 +174,8 @@ def test_can_support_cors(smoke_test_app):
 
 def test_to_dict_is_also_json_serializable(smoke_test_app):
     assert 'headers' in smoke_test_app.get_json('/todict')
+
+
+def test_multfile_support(smoke_test_app):
+    response = smoke_test_app.get_json('/multifile')
+    assert response == {'message': 'success'}

--- a/tests/integration/testapp/app.py
+++ b/tests/integration/testapp/app.py
@@ -78,3 +78,9 @@ def supports_cors():
 @app.route('/todict', methods=['GET'])
 def todict():
     return app.current_request.to_dict()
+
+
+@app.route('/multifile')
+def multifile():
+    from chalicelib import MESSAGE
+    return {"message": MESSAGE}

--- a/tests/integration/testapp/chalicelib/__init__.py
+++ b/tests/integration/testapp/chalicelib/__init__.py
@@ -1,0 +1,1 @@
+MESSAGE = "success"


### PR DESCRIPTION
There's been several approaches proposed:

1. Support either 'app.py' *or* an ``app/`` directory.
2. Recursively find all python modules/packages (similar to what
   ``find_packages(.)`` does.
3. Have some type of manifest file that includes/excludes files.
4. Include a hard coded directory if it exists.

This commit implements option 4, which I think has a good balance
of control vs. ease of use:

* If you want something included in the deployment package, put it
  in this directory.  This works whether it's a python file or not.
* If you don't something included in your deployment package, don't
  include it in ``chalicelib/``.

cc @kyleknap @JordonPhillips 