### PR TITLE
Initial commit of chalice local command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -860,6 +860,53 @@ http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorize
 
 Only requests sent with a valid `X-Api-Key` header will be accepted.
 
+Tutorial: Local Mode
+====================
+
+As you develop your application, you may want to experiment locally  before
+deploying your changes.  You can use ``chalice local`` to spin up a local
+HTTP server you can use for testing.
+
+For example, if we have the following ``app.py`` file:
+
+.. code-block:: python
+
+    from chalice import Chalice
+
+    app = Chalice(app_name='helloworld')
+
+
+    @app.route('/')
+    def index():
+        return {'hello': 'world'}
+
+
+We can run ``chalice local`` to test this API locally:
+
+
+    $ chalice local
+    Serving on localhost:8000
+
+We can now test our API using ``localhost:8000``::
+
+    $ http localhost:8000/
+    HTTP/1.0 200 OK
+    Content-Length: 18
+    Content-Type: application/json
+    Date: Thu, 27 Oct 2016 20:08:43 GMT
+    Server: BaseHTTP/0.3 Python/2.7.11
+
+    {
+        "hello": "world"
+    }
+
+
+The ``chalice local`` command *does not* assume the
+role associated with your lambda function, so you'll
+need to use an ``AWS_PROFILE`` that has sufficient permissions
+to your AWS resources used in your ``app.py``.
+
+
 Backlog
 =======
 
@@ -867,8 +914,6 @@ These are features that are in the backlog:
 
 * Adding full support for API gateway stages - `issue 20
   <https://github.com/awslabs/chalice/issues/20>`__
-* Adding support for more than ``app.py`` - `issue 21
-  <https://github.com/awslabs/chalice/issues/21>`__
 
 Please share any feedback on the above issues.  We'd also love
 to hear from you.  Please create any Github issues for additional

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -132,9 +132,15 @@ def cli(ctx):
 
 
 @cli.command()
+@click.option('--project-dir',
+              help='The project directory.  Defaults to CWD')
 @click.pass_context
-def local(ctx):
-    click.echo("Local command")
+def local(ctx, project_dir):
+    if project_dir is None:
+        project_dir = os.getcwd()
+    os.chdir(project_dir)
+    app_obj = load_chalice_app(project_dir)
+    run_local_server(app_obj)
 
 
 @cli.command()
@@ -261,6 +267,12 @@ def new_project(ctx, project_name, profile):
         f.write(TEMPLATE_APP % project_name)
     with open(os.path.join(project_name, '.gitignore'), 'w') as f:
         f.write(GITIGNORE)
+
+
+def run_local_server(app_obj):
+    from chalice import local
+    server = local.LocalDevServer(app_obj)
+    server.serve_forever()
 
 
 def main():

--- a/chalice/local.py
+++ b/chalice/local.py
@@ -1,0 +1,195 @@
+"""Dev server used for running a chalice app locally.
+
+This is intended only for local development purposes.
+
+"""
+import json
+import functools
+from collections import namedtuple
+import BaseHTTPServer
+
+from chalice import ChaliceViewError
+from chalice.app import ChaliceError
+from typing import List  # noqa
+
+
+MatchResult = namedtuple('MatchResult', ['route', 'captured'])
+
+
+class RouteMatcher(object):
+    def __init__(self, route_urls):
+        # type: (List[str]) -> None
+        # Sorting the route_urls ensures we always check
+        # the concrete routes for a prefix before the
+        # variable/capture parts of the route, e.g
+        # '/foo/bar' before '/foo/{capture}'
+        self.route_urls = sorted(route_urls)
+
+    def match_route(self, url):
+        # type: (str) -> MatchResult
+        """Match the url against known routes.
+
+        This method takes a concrete route "/foo/bar", and
+        matches it against a set of routes.  These routes can
+        use param substitution corresponding to API gateway patterns.
+        For example::
+
+            match_route('/foo/bar') -> '/foo/{name}'
+
+        """
+        # Otherwise we need to check for param substitution
+        parts = url.split('/')
+        captured = {}
+        for route_url in self.route_urls:
+            url_parts = route_url.split('/')
+            if len(parts) == len(url_parts):
+                for i, j in zip(parts, url_parts):
+                    if j.startswith('{') and j.endswith('}'):
+                        captured[j[1:-1]] = i
+                        continue
+                    if i != j:
+                        break
+                else:
+                    return MatchResult(route_url, captured)
+        raise ValueError("No matching route found for: %s" % url)
+
+
+class LambdaEventConverter(object):
+    """Convert an HTTP request to an event dict used by lambda."""
+    def __init__(self, route_matcher):
+        # type: (RouteMatcher) -> None
+        self._route_matcher = route_matcher
+
+    def create_lambda_event(self, method, path, headers, body=None):
+        view_route = self._route_matcher.match_route(path)
+        if body is None:
+            body = '{}'
+        json_body = {}
+        if headers.get('content-type', '') == 'application/json':
+            json_body = json.loads(body)
+        base64_body = body.encode('base64')
+        return {
+            'context': {
+                'http-method': method,
+                'resource-path': view_route.route,
+            },
+            'params': {
+                'header': dict(headers),
+                'path': view_route.captured,
+                'querystring': {},
+            },
+            'body-json': json_body,
+            'base64-body': base64_body,
+            'stage-variables': {},
+        }
+
+
+class ChaliceRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
+
+    protocol = 'HTTP/1.1'
+
+    def __init__(self, request, client_address, server, app_object):
+        self.app_object = app_object
+        self.event_converter = LambdaEventConverter(
+            RouteMatcher(list(app_object.routes)))
+        BaseHTTPServer.BaseHTTPRequestHandler.__init__(
+            self, request, client_address, server)
+
+    def _generic_handle(self):
+        lambda_event = self._generate_lambda_event()
+        self._do_invoke_view_function(lambda_event)
+
+    def _do_invoke_view_function(self, lambda_event):
+        lambda_context = None
+        try:
+            response = self.app_object(lambda_event, lambda_context)
+            self._send_http_response(lambda_event, response)
+        except ChaliceViewError as e:
+            response = {
+                'Code': e.__class__.__name__,
+                'Message': str(e)
+            }
+            self._send_http_response(lambda_event, response,
+                                     status_code=e.STATUS_CODE)
+        except ChaliceError as e:
+            # This is a bit unfortunate, but in many cases
+            # API gateway will return a 403 instead of a 500
+            # or a 404.  In this case there's a slight difference
+            # in behavior in local mode where any ChaliceError
+            # just gets a plain old 500 response.
+            response = {'message': str(e)}
+            self._send_http_response(lambda_event, response,
+                                     status_code=500)
+
+    def _send_http_response(self, lambda_event, response, status_code=200):
+        json_response = json.dumps(response)
+        self.send_response(status_code)
+        self.send_header('Content-Length', str(len(json_response)))
+        self.send_header('Content-Type', 'application/json')
+        if self._cors_enabled_for_route(lambda_event):
+            self.send_header('Access-Control-Allow-Origin', '*')
+        self.end_headers()
+        self.wfile.write(json_response)
+
+    def _generate_lambda_event(self):
+        content_length = int(self.headers.get('content-length', '0'))
+        body = None
+        if content_length > 0:
+            body = self.rfile.read(content_length)
+        lambda_event = self.event_converter.create_lambda_event(
+            method=self.command, path=self.path, headers=dict(self.headers),
+            body=body,
+        )
+        return lambda_event
+
+    do_GET = do_PUT = do_POST = do_HEAD = _generic_handle
+
+    def do_OPTIONS(self):
+        # This can either be because the user's provided an OPTIONS method
+        # *or* this is a preflight request, which chalice automatically
+        # sets up for you.
+        lambda_event = self._generate_lambda_event()
+        if self._has_user_defined_options_method(lambda_event):
+            self._do_invoke_view_function(lambda_event)
+        else:
+            # Otherwise this is a preflight request which we automatically
+            # generate.
+            self._send_autogen_options_response()
+
+    def _cors_enabled_for_route(self, lambda_event):
+        route_key = lambda_event['context']['resource-path']
+        route_entry = self.app_object.routes[route_key]
+        return route_entry.cors
+
+    def _has_user_defined_options_method(self, lambda_event):
+        route_key = lambda_event['context']['resource-path']
+        route_entry = self.app_object.routes[route_key]
+        return 'OPTIONS' in route_entry.methods
+
+    def _send_autogen_options_response(self):
+        self.send_response(200)
+        self.send_header(
+            'Access-Control-Allow-Headers',
+            'Content-Type,X-Amz-Date,Authorization,'
+            'X-Api-Key,X-Amz-Security-Token'
+        )
+        self.send_header('Access-Control-Allow-Methods',
+                         'GET,HEAD,PUT,POST,OPTIONS')
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.end_headers()
+
+
+class LocalDevServer(object):
+    def __init__(self, app_object, handler_cls=ChaliceRequestHandler,
+                 server_cls=BaseHTTPServer.HTTPServer):
+        self.app_object = app_object
+        self._wrapped_handler = functools.partial(
+            handler_cls, app_object=app_object)
+        self.server = server_cls(('', 8000), self._wrapped_handler)
+
+    def handle_single_request(self):
+        self.server.handle_request()
+
+    def serve_forever(self):
+        print "Serving on localhost:8000"
+        self.server.serve_forever()

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -1,0 +1,249 @@
+from chalice import local, BadRequestError
+import json
+import pytest
+from pytest import fixture
+from StringIO import StringIO
+
+from chalice import app
+
+
+class ChaliceStubbedHandler(local.ChaliceRequestHandler):
+    requestline = ''
+    request_version = 'HTTP/1.1'
+
+    def setup(self):
+        self.rfile = StringIO()
+        self.wfile = StringIO()
+        self.requestline = ''
+
+    def finish(self):
+        pass
+
+
+@fixture
+def sample_app():
+    demo = app.Chalice('demo-app')
+
+    @demo.route('/index', methods=['GET'])
+    def index():
+        return {'hello': 'world'}
+
+    @demo.route('/names/{name}', methods=['GET'])
+    def name(name):
+        return {'provided-name': name}
+
+    @demo.route('/put', methods=['PUT'])
+    def put():
+        return {'body': demo.current_request.json_body}
+
+    @demo.route('/cors', methods=['GET', 'PUT'], cors=True)
+    def cors():
+        return {'cors': True}
+
+    @demo.route('/options', methods=['OPTIONS'])
+    def options():
+        return {'options': True}
+
+    @demo.route('/badrequest')
+    def badrequest():
+        raise BadRequestError('bad-request')
+
+    return demo
+
+
+@fixture
+def handler(sample_app):
+    chalice_handler = ChaliceStubbedHandler(None, ('127.0.0.1', 2000), None,
+                                            app_object=sample_app)
+    chalice_handler.sample_app = sample_app
+    return chalice_handler
+
+
+def _get_body_from_response_stream(handler):
+    # This is going to include things like status code and
+    # response headers in the raw stream.  We just care about the
+    # body for now so we'll split lines.
+    raw_response = handler.wfile.getvalue()
+    body = raw_response.splitlines()[-1]
+    return json.loads(body)
+
+
+def test_can_convert_request_handler_to_lambda_event(handler):
+    handler.command = 'GET'
+    handler.path = '/index'
+    handler.headers = {'content-type': 'application/json'}
+    handler.do_GET()
+
+    body = _get_body_from_response_stream(handler)
+    assert body == {'hello': 'world'}
+
+
+def test_can_route_url_params(handler):
+    handler.command = 'GET'
+    handler.path = '/names/james'
+    handler.headers = {'content-type': 'application/json'}
+
+    handler.do_GET()
+    body = _get_body_from_response_stream(handler)
+    assert body == {'provided-name': 'james'}
+
+
+def test_can_route_put_with_body(handler):
+    handler.command = 'PUT'
+    handler.path = '/put'
+    body = '{"foo": "bar"}'
+    handler.headers = {'content-type': 'application/json',
+                       'content-length': len(body)}
+    handler.rfile.write(body)
+    handler.rfile.seek(0)
+
+    handler.do_PUT()
+    response_body = _get_body_from_response_stream(handler)
+    assert response_body == {'body': {'foo': 'bar'}}
+
+
+def test_will_respond_with_cors_enabled(handler):
+    handler.command = 'GET'
+    handler.path = '/cors'
+    handler.headers = {'content-type': 'application/json', 'origin': 'null'}
+    handler.do_GET()
+    response_lines = handler.wfile.getvalue().splitlines()
+    assert 'Access-Control-Allow-Origin: *' in response_lines
+
+
+def test_can_preflight_request(handler):
+    handler.command = 'OPTIONS'
+    handler.path = '/cors'
+    handler.headers = {'content-type': 'application/json', 'origin': 'null'}
+    handler.do_OPTIONS()
+    response_lines = handler.wfile.getvalue().splitlines()
+    assert 'Access-Control-Allow-Origin: *' in response_lines
+
+
+def test_non_preflight_options_request(handler):
+    handler.command = 'OPTIONS'
+    handler.path = '/options'
+    handler.headers = {'content-type': 'application/json', 'origin': 'null'}
+    handler.do_OPTIONS()
+    body = _get_body_from_response_stream(handler)
+    assert body == {'options': True}
+
+
+def test_errors_converted_to_json_response(handler):
+    handler.command = 'GET'
+    handler.path = '/badrequest'
+    handler.headers = {'content-type': 'application/json'}
+
+    handler.do_GET()
+    body = _get_body_from_response_stream(handler)
+    assert body == {'Code': 'BadRequestError',
+                    'Message': 'BadRequestError: bad-request'}
+
+
+def test_unsupported_methods_raise_error(handler):
+    handler.command = 'POST'
+    handler.path = '/index'
+    handler.headers = {'content-type': 'application/json'}
+    handler.do_POST()
+
+    body = _get_body_from_response_stream(handler)
+    assert body == {'message': 'Unsupported method: POST'}
+
+
+@pytest.mark.parametrize('actual_url,matched_url', [
+    ('/foo', '/foo'),
+    ('/foo/bar', '/foo/bar'),
+    ('/foo/other', '/foo/{capture}'),
+    ('/names/foo', '/names/{capture}'),
+    ('/names/bar', '/names/{capture}'),
+    ('/nomatch', None),
+    ('/names/bar/wrong', None),
+    ('/a/z/c', '/a/{capture}/c'),
+    ('/a/b/c', '/a/b/c'),
+])
+def test_can_match_exact_route(actual_url, matched_url):
+    matcher = local.RouteMatcher([
+        '/foo', '/foo/{capture}', '/foo/bar',
+        '/names/{capture}',
+        '/a/{capture}/c', '/a/b/c'
+    ])
+    if matched_url is not None:
+        assert matcher.match_route(actual_url).route == matched_url
+    else:
+        with pytest.raises(ValueError):
+            matcher.match_route(actual_url)
+
+
+def test_can_create_lambda_event():
+    converter = local.LambdaEventConverter(
+        local.RouteMatcher(['/foo/bar', '/foo/{capture}']))
+    event = converter.create_lambda_event(
+        method='GET',
+        path='/foo/other',
+        headers={'content-type': 'application/json'}
+    )
+    assert event == {
+        'context': {
+            'http-method': 'GET',
+            'resource-path': '/foo/{capture}',
+        },
+        'params': {
+            'header': {'content-type': 'application/json'},
+            'path': {'capture': 'other'},
+            'querystring': {},
+        },
+        'body-json': {},
+        'base64-body': json.dumps({}).encode("base64"),
+        'stage-variables': {},
+    }
+
+
+def test_can_create_lambda_event_for_put_request():
+    converter = local.LambdaEventConverter(
+        local.RouteMatcher(['/foo/bar', '/foo/{capture}']))
+    event = converter.create_lambda_event(
+        method='PUT',
+        path='/foo/other',
+        headers={'content-type': 'application/json'},
+        body='{"foo": "bar"}',
+    )
+    assert event == {
+        'context': {
+            'http-method': 'PUT',
+            'resource-path': '/foo/{capture}',
+        },
+        'params': {
+            'header': {'content-type': 'application/json'},
+            'path': {'capture': 'other'},
+            'querystring': {},
+        },
+        'body-json': {'foo': 'bar'},
+        'base64-body': json.dumps({'foo': 'bar'}).encode("base64"),
+        'stage-variables': {},
+    }
+
+
+def test_can_create_lambda_event_for_post_with_formencoded_body():
+    converter = local.LambdaEventConverter(
+        local.RouteMatcher(['/foo/bar', '/foo/{capture}']))
+    form_body = 'foo=bar&baz=qux'
+    event = converter.create_lambda_event(
+        method='POST',
+        path='/foo/other',
+        headers={'content-type': 'application/x-www-form-urlencoded'},
+        body=form_body,
+    )
+    assert event == {
+        'context': {
+            'http-method': 'POST',
+            'resource-path': '/foo/{capture}',
+        },
+        'params': {
+            'header': {'content-type': 'application/x-www-form-urlencoded'},
+            'path': {'capture': 'other'},
+            'querystring': {},
+        },
+        'body-json': {},
+        'base64-body': form_body.encode('base64'),
+        'stage-variables': {},
+    }


### PR DESCRIPTION
This command will spin up a local http server that you can
use to run your chalice apps.  The intent is to provide a quicker
feedback loop while developing your code.  Previously you would
have to deploy to API gateway in order to test changes to your API.

There's one main feature that's missing from chalice local: this
does not try to assume the role that's associated with lambda function.

In order to do this, we'll likely need to update the trust policy
of the role to give the AWS user being used locally the ability
to assume the role.  Not exactly sure how I want this to work so
I haven't added that as part of this commit.

Closes #22.

cc @kyleknap @JordonPhillips 