### PR TITLE
Return 405 Method Not Allowed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ sample/
 venv
 docs/build/
 .idea
+*.py?
+__pycache__/

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -42,6 +42,10 @@ class NotFoundError(ChaliceViewError):
     STATUS_CODE = 404
 
 
+class MethodNotAllowedError(ChaliceViewError):
+    STATUS_CODE = 405
+
+
 class ConflictError(ChaliceViewError):
     STATUS_CODE = 409
 
@@ -235,7 +239,7 @@ class Chalice(object):
             raise ChaliceError("No view function for: %s" % resource_path)
         route_entry = self.routes[resource_path]
         if http_method not in route_entry.methods:
-            raise ChaliceError("Unsupported method: %s" % http_method)
+            raise MethodNotAllowedError("Unsupported method: %s" % http_method)
         view_function = route_entry.view_function
         function_args = [event['params']['path'][name]
                          for name in route_entry.view_args]

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -126,8 +126,23 @@ def test_will_pass_captured_params_to_view(sample_app):
 
 def test_error_on_unsupported_method(sample_app):
     event = create_event('/name/{name}', 'POST', {'name': 'james'})
-    with pytest.raises(app.ChaliceError):
+    with pytest.raises(app.MethodNotAllowedError):
         sample_app(event, context=None)
+
+
+def test_error_on_unsupported_method_has_correct_status_code(sample_app):
+    event = create_event('/name/{name}', 'POST', {'name': 'james'})
+    with pytest.raises(app.MethodNotAllowedError) as execinfo:
+        sample_app(event, context=None)
+    assert execinfo.value.STATUS_CODE == 405
+
+
+def test_error_on_unsupported_method_gives_feedback_on_method(sample_app):
+    method = 'POST'
+    event = create_event('/name/{name}', method, {'name': 'james'})
+    with pytest.raises(app.MethodNotAllowedError) as execinfo:
+        sample_app(event, context=None)
+    assert method in str(execinfo.value)
 
 
 def test_no_view_function_found(sample_app):


### PR DESCRIPTION
Addresses issue #159 to return a `405` status code when the method is not supported by the route.