### PR TITLE
Add path params as requestParam in put_method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ Next Release (TBD)
 * Return 405 when method is not supported when running
   ``chalice local``
   (`#159 <https://github.com/awslabs/chalice/issues/159>`__)
+* Add path params as requestParameters so they can be used
+  in generated SDKs as well as cache keys
+  (`#163 <https://github.com/awslabs/chalice/issues/163>`__)
 
 
 0.4.0

--- a/tests/unit/test_deployer.py
+++ b/tests/unit/test_deployer.py
@@ -437,3 +437,20 @@ def test_cant_have_options_with_cors(sample_app):
 
     with pytest.raises(ValueError):
         validate_routes(sample_app.routes)
+
+
+def test_apig_methods(stubbed_session):
+    gateway_stub = stubbed_session.stub('apigateway')
+    gateway_stub.put_method(
+        authorizationType='NONE',
+        httpMethod='GET',
+        resourceId='resource_id',
+        restApiId='rest_api_id',
+        requestParameters={'method.request.path.name': True},
+    ).returns({})
+    apig = APIGatewayMethods(
+        stubbed_session.create_client('apigateway'), 'rest_api_id')
+
+    stubbed_session.activate_stubs()
+    apig.create_method_request('resource_id', 'GET', url_params=['name'])
+    stubbed_session.verify_stubs()


### PR DESCRIPTION
This fixes an issue where you can't leverage certain
API gateway features unless you specify the request parameters to
include the params in the URL,
e.g /users/{name} -> method.request.path.name: True

The specific problems I ran into:

* Generated javascript SDK does not include these params
* Can't use the params as cache keys.

Closes https://github.com/awslabs/chalice/issues/163