### PR TITLE
Add policy mapping for ElasticSearch

### DIFF
--- a/chalice/policies.json
+++ b/chalice/policies.json
@@ -326,6 +326,23 @@
     "UnassignPrivateIpAddresses": "ec2:UnassignPrivateIpAddresses",
     "UnmonitorInstances": "ec2:UnmonitorInstances"
   },
+  "es": {
+    "ESHttpDelete": "es:ESHttpDelete",
+    "ESHttpGet": "es:ESHttpGet",
+    "ESHttpHead": "es:ESHttpHead",
+    "ESHttpPost": "es:ESHttpPost",
+    "ESHttpPut": "es:ESHttpPut",
+    "CreateElasticsearchDomain": "es:CreateElasticsearchDomain",
+    "DescribeElasticsearchDomain": "es:DescribeElasticsearchDomain",
+    "DescribeElasticsearchDomains": "es:DescribeElasticsearchDomains",
+    "DescribeElasticsearchDomainConfig": "es:DescribeElasticsearchDomainConfig",
+    "DeleteElasticsearchDomain": "es:DeleteElasticsearchDomain",
+    "ListDomainNames": "es:ListDomainNames",
+    "AddTags": "es:AddTags",
+    "ListTags": "es:ListTags",
+    "RemoveTags": "es:RemoveTags",
+    "UpdateElasticsearchDomainConfig": "es:UpdateElasticsearchDomainConfig"
+  },
   "elasticache": {
     "AuthorizeCacheSecurityGroupIngress": "elasticache:AuthorizeCacheSecurityGroupIngress",
     "CreateCacheCluster": "elasticache:CreateCacheCluster",


### PR DESCRIPTION
http://boto3.readthedocs.io/en/latest/reference/services/es.html?highlight=es#id1

`boto 1.4.1` and higher has `ElasticSearch` support as well.
An operation was requested that requires `es` support to be policy allowed in, but `policies.json` was configured without es support.
