### PR TITLE
Add "chalice url" command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Next Release (TBD)
   (`#163 <https://github.com/awslabs/chalice/issues/163>`__)
 * Map cognito user pool claims as part of request context
   (`#165 <https://github.com/awslabs/chalice/issues/165>`__)
+* Add ``chalice url`` command to print the deployed URL
+  (`#169 <https://github.com/awslabs/chalice/pull/169>`__)
 
 
 0.4.0

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -34,8 +34,8 @@ class Config(object):
         return self._chain_lookup('app_name')
 
     @property
-    def stage_name(self):
-        return self._chain_lookup('stage_name')
+    def stage(self):
+        return self._chain_lookup('stage')
 
     @property
     def manage_iam_role(self):

--- a/chalice/deployer.py
+++ b/chalice/deployer.py
@@ -783,7 +783,7 @@ class APIGatewayDeployer(object):
         route_builder.build_resources(url_trie)
         # And finally, you need an actual deployment to deploy the changes to
         # API gateway.
-        stage = config.stage_name or 'dev'
+        stage = config.stage or 'dev'
         print "Deploying to:", stage
         self._aws_client.deploy_rest_api(rest_api_id, stage)
         return rest_api_id, self._aws_client.region_name, stage


### PR DESCRIPTION
This command will print the API gateway URL for the current app.

This is the same value that's printed at the end of `chalice deploy`.  This has several benefits:

* You can programatically get the http url endpoint instead of using `chalice deploy | tail -n 1`.
* There was previously no easy way to get the deployed url.  If you've already deployed your app but didn't record the deployed url, you'd have to look up the `rest_api_id` yourself and manually construct the URL (or look it up in the console).

As part of this change, I refactored the CLI logic to remove some duplicate code when creating the `chalice.config.Config` object.  This should make it easier for new commands that require a config object.