### PR TITLE
Fix bug for finding root resources if multiple already exist

### DIFF
--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -139,8 +139,11 @@ class TypedAWSClient(object):
 
     def get_root_resource_for_api(self, rest_api_id):
         # type: (str) -> Dict[str, Any]
-        root_resource = self._client('apigateway').get_resources(
-            restApiId=rest_api_id)['items'][0]
+        resources = [ x for x
+                      in self._client('apigateway').get_resources(restApiId=rest_api_id)['items'] 
+                      if x['path'] ==  '/' ]
+        assert len(resources) == 1
+        root_resource = resources[0]
         return root_resource
 
     def get_resources_for_api(self, rest_api_id):


### PR DESCRIPTION
I'm experimenting with using chalice as a library.  I found that if there are multiple resources already created then get_root_resource_for_api may not actually return the root resource. 

This fixes that.  I haven't shown that it fixes any particular bug in chalice as an application.  