### PR TITLE
Make creation not fail even if things already exist.  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/build/
 .idea
 *.py?
 __pycache__/
+*.pyc

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -139,8 +139,11 @@ class TypedAWSClient(object):
 
     def get_root_resource_for_api(self, rest_api_id):
         # type: (str) -> Dict[str, Any]
-        root_resource = self._client('apigateway').get_resources(
-            restApiId=rest_api_id)['items'][0]
+        resources = [ x for x
+                      in self._client('apigateway').get_resources(restApiId=rest_api_id)['items'] 
+                      if x['path'] ==  '/' ]
+        assert len(resources) == 1
+        root_resource = resources[0]
         return root_resource
 
     def get_resources_for_api(self, rest_api_id):

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -15,6 +15,7 @@ this class to get improved type checking across chalice.
 """
 import time
 import json
+import re
 
 import botocore.session
 import botocore.exceptions
@@ -184,6 +185,16 @@ class TypedAWSClient(object):
             pathPart=path_part,
         )
         return response
+
+    def get_rest_resource_by_path(self, rest_api_id, path_part):
+        # type: (str, str, str) -> Dict[str, Any]
+        client = self._client('apigateway')
+        resources = [ x for x
+                      in self._client('apigateway').get_resources(restApiId=rest_api_id)['items'] 
+                      if re.search(path_part + '$', x['path']) ]
+        assert len(resources) == 1
+        found_resource = resources[0]
+        return found_resource
 
     def add_permission_for_apigateway_if_needed(self, function_name,
                                                 region_name, account_id,

--- a/chalice/deployer.py
+++ b/chalice/deployer.py
@@ -307,11 +307,20 @@ class APIGatewayResourceCreator(object):
             # If there's no resource_id we need to create it.
             if current['resource_id'] is None:
                 assert current['parent_resource_id'] is not None, current
-                response = self.awsclient.create_rest_resource(
-                    self.rest_api_id, current['parent_resource_id'],
-                    current['name']
-                )
-                new_resource_id = response['id']
+                try:
+                    response = self.awsclient.create_rest_resource(
+                        self.rest_api_id, current['parent_resource_id'],
+                        current['name']
+                    )
+                except Exception as ce:
+                    if "ConflictException" in str(ce):
+                        response=self.awsclient.get_rest_resource_by_path(
+                            self.rest_api_id, 
+                            current['name']
+                        )
+                    else:
+                        raise(ce)
+                    new_resource_id = response['id']
                 current['resource_id'] = new_resource_id
                 for child in current['children']:
                     current['children'][child]['parent_resource_id'] = \


### PR DESCRIPTION
I want to use bits of chalice as a library which would allow deploying parts of an API even if other parts are already deployed.  

In order to work in this direction I made a patch which makes the actual API creation functions run inside a try/except.  Currently it's a bit of a hack which I'm showing primarily to get comments.  If you would be interested to merge then I would be willing to clean this up as suggested.  