### PR TITLE
Give up to 30 seconds of retry for creating lambda function

### DIFF
--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -23,7 +23,7 @@ from typing import Any, Optional, Dict, Callable  # noqa
 
 class TypedAWSClient(object):
 
-    LAMBDA_CREATE_ATTEMPTS = 5
+    LAMBDA_CREATE_ATTEMPTS = 10
     DELAY_TIME = 3
 
     def __init__(self, session, sleep=time.sleep):

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -300,7 +300,7 @@ class TestCreateLambdaFunction(object):
             'Role': 'myarn',
             'Timeout': 60,
         }
-        for _ in range(5):
+        for _ in range(TypedAWSClient.LAMBDA_CREATE_ATTEMPTS):
             stubbed_session.stub('lambda').create_function(
                 **kwargs).raises_error(
                 error_code='InvalidParameterValueException', message='')


### PR DESCRIPTION
This accounts for the propagation time when first creating a role.  15 seconds is not enough, I'll still occasionally get errors on initial deploy.