### PR TITLE
Introduce a 204 No Content handler

### DIFF
--- a/chalice/__init__.py
+++ b/chalice/__init__.py
@@ -1,7 +1,7 @@
 from chalice.app import Chalice
 from chalice.app import (
     ChaliceViewError, BadRequestError, UnauthorizedError, ForbiddenError,
-    NotFoundError, ConflictError, TooManyRequestsError
+    NotFoundError, ConflictError, TooManyRequestsError, SuccessNoContent
 )
 
 

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -54,6 +54,10 @@ class TooManyRequestsError(ChaliceViewError):
     STATUS_CODE = 429
 
 
+class SuccessNoContent(ChaliceViewError):
+    STATUS_CODE = 204
+
+
 ALL_ERRORS = [
     ChaliceViewError,
     BadRequestError,
@@ -61,7 +65,8 @@ ALL_ERRORS = [
     UnauthorizedError,
     ForbiddenError,
     ConflictError,
-    TooManyRequestsError]
+    TooManyRequestsError,
+    SuccessNoContent]
 
 
 class CaseInsensitiveMapping(Mapping):

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -5,7 +5,7 @@ import json
 import pytest
 from pytest import fixture
 from chalice import app
-from chalice import NotFoundError
+from chalice import NotFoundError, SuccessNoContent
 
 
 def create_event(uri, method, path, content_type='application/json'):
@@ -50,6 +50,10 @@ def sample_app():
     @demo.route('/name/{name}', methods=['GET'])
     def name(name):
         return {'provided-name': name}
+
+    @demo.route('/successnocontent', methods=['GET'])
+    def successnocontent():
+        raise SuccessNoContent
 
     return demo
 
@@ -144,6 +148,19 @@ def test_error_on_unsupported_method_gives_feedback_on_method(sample_app):
     with pytest.raises(app.MethodNotAllowedError) as execinfo:
         sample_app(event, context=None)
     assert method in str(execinfo.value)
+
+
+def test_error_on_success_nocontent(sample_app):
+    event = create_event('/successnocontent', 'GET', {})
+    with pytest.raises(app.SuccessNoContent):
+        sample_app(event, context=None)
+
+
+def test_error_on_success_nocontent_has_correct_status_code(sample_app):
+    event = create_event('/successnocontent', 'GET', {})
+    with pytest.raises(app.SuccessNoContent) as execinfo:
+        sample_app(event, context=None)
+    assert execinfo.value.STATUS_CODE == 204
 
 
 def test_no_view_function_found(sample_app):


### PR DESCRIPTION
Needed to return a 204 NO CONTENT from a Chalice API.  This creates a `SuccessNoContent` exception that returns a `ChaliceViewError` but with STATUS_CODE set to 204.

This is not likely a sustainable design for extending chalice, however for this specific use without any content returned, it works.