### PR TITLE
Update typing module version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
     'click==6.2',
     'botocore>=1.4.8,<2.0.0',
     'virtualenv>=15.0.0,<16.0.0',
-    'typing==3.5.1.0',
+    'typing==3.5.2.2',
 ]
 
 


### PR DESCRIPTION
I want to use Text alias defined in typing module since version 3.5.2 on my chalice application.

* [This](https://github.com/python/typing/commit/2009065ee4b81c48f4ad8d6fccb8958eb3fc0985) is related commit.

But chalice needs to require typing=='3.5.1.0', therefore following error has occured.

```
pkg_resources.DistributionNotFound: The 'typing==3.5.1.0' distribution was not found and is required by chalice
```

If you don't want to update version, please let me know an alternative plan if you know.

Best regards.