### PR TITLE
Add support for a vendor/ folder

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -59,6 +59,7 @@ Topics
    topics/multifile
    topics/logging
    topics/sdks
+   topics/packaging
 
 
 API Reference

--- a/docs/source/topics/packaging.rst
+++ b/docs/source/topics/packaging.rst
@@ -1,0 +1,88 @@
+App Packaging
+=============
+
+In order to deploy your chalice app, a zip file is created that
+contains your application and all third party packages your application
+rqeuires.  This file is used by AWS Lambda and is referred
+to as a deployment package.
+
+Chalice will automatically create this deployment package for you, and offers
+several features to make this easier to manage.  Chalice allows you to
+clearly separate application specific modules and packages you are writing
+from 3rd party package dependencies.
+
+
+App Directories
+---------------
+
+You have two options to structure application specific code/config:
+
+* **app.py** - This file includes all your route information and is always
+  included in the deployment package.
+* **chalicelib/** - This directory (if it exists) is included in the
+  deployment package.  This is where you can add config files and additional
+  application modules if you prefer not to have all your app code in the
+  ``app.py`` file.
+
+See :doc:`multifile` for more info on the ``chalicelib/`` directory.  Both the
+``app.py`` and the ``chalicelib/`` directory are intended for code that you
+write yourself.
+
+
+3rd Party Packages
+------------------
+
+There are two options for handling python package dependencies:
+
+* **requirements.txt** - During the packaging process, chalice will
+  run ``pip install -r requirements.txt`` in a virtual environment
+  and automatically install 3rd party python packages into the deployment
+  package.
+* **vendor/** - The *contents* of this directory are automatically added to
+  the top level of the deployment package.
+
+Chalice will also check for an optional ``vendor/`` directory in the project
+root directory.  The contents of this directory are automatically included in
+the top level of the deployment package (see :ref:`package-examples` for
+specific examples).  The ``vendor/`` directory is helpful in these scenarios:
+
+* You need to include custom packages or binary content that is not accessible
+  via ``pip``.  These may be internal packages that aren't public.
+* You need to use C extensions, and you're not developing on Linux.
+
+
+Examples
+--------
+
+Suppose I have the following app structure::
+
+    .
+    ├── app.py
+    ├── chalicelib
+    │   ├── __init__.py
+    │   └── utils.py
+    ├── requirements.txt
+    └── vendor
+        └── internalpackage
+            └── __init__.py
+
+And the ``requirements.txt`` file had one requirement::
+
+    $ cat requirements.txt
+    sortedcontainers==1.5.4
+
+Then the final deployment package directory structure would look like this::
+
+    .
+    ├── app.py
+    ├── chalicelib
+    │   ├── __init__.py
+    │   └── utils.py
+    ├── internalpackage
+    │   └── __init__.py
+    └── sortedcontainers
+        └── __init__.py
+
+
+This directory structure is then zipped up and sent to AWS Lambda during the
+deployment process.

--- a/tests/functional/test_deployer.py
+++ b/tests/functional/test_deployer.py
@@ -155,3 +155,37 @@ def test_subsequent_deploy_replaces_chalicelib(tmpdir, chalice_deployer):
         # And chalicelib/__init__.py should no longer be
         # in the zipfile because we deleted it in the appdir.
         assert 'chalicelib/__init__.py' not in f.namelist()
+
+
+def test_vendor_dir_included(tmpdir, chalice_deployer):
+    appdir = _create_app_structure(tmpdir)
+    vendor = appdir.mkdir('vendor')
+    extra_package = vendor.mkdir('mypackage')
+    extra_package.join('__init__.py').write('# Test package')
+    name = chalice_deployer.create_deployment_package(str(appdir))
+    with zipfile.ZipFile(name) as f:
+        _assert_in_zip('mypackage/__init__.py', '# Test package', f)
+
+
+def test_subsequent_deploy_replaces_vendor_dir(tmpdir, chalice_deployer):
+    appdir = _create_app_structure(tmpdir)
+    vendor = appdir.mkdir('vendor')
+    extra_package = vendor.mkdir('mypackage')
+    extra_package.join('__init__.py').write('# v1')
+    name = chalice_deployer.create_deployment_package(str(appdir))
+    # Now we update a package in vendor/ with a new version.
+    extra_package.join('__init__.py').write('# v2')
+    name = chalice_deployer.create_deployment_package(str(appdir))
+    with zipfile.ZipFile(name) as f:
+        _assert_in_zip('mypackage/__init__.py', '# v2', f)
+
+
+def test_zip_filename_changes_on_vendor_update(tmpdir, chalice_deployer):
+    appdir = _create_app_structure(tmpdir)
+    vendor = appdir.mkdir('vendor')
+    extra_package = vendor.mkdir('mypackage')
+    extra_package.join('__init__.py').write('# v1')
+    first = chalice_deployer.deployment_package_filename(str(appdir))
+    extra_package.join('__init__.py').write('# v2')
+    second = chalice_deployer.deployment_package_filename(str(appdir))
+    assert first != second


### PR DESCRIPTION
This will support adding 3rd party binary packages, or packages/content that's not installable via pip.

It will also suffice for now to install packages with C extensions until smarter support is added to the requirements.txt file handling.