### PR TITLE
fix for content-type that contain charset

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -96,7 +96,7 @@ class Request(object):
         #: The parsed JSON from the body.  This value should
         #: only be set if the Content-Type header is application/json,
         #: which is the default content type value in chalice.
-        if 'application/json' in self.headers.get('content-type'):
+        if 'application/json' in self.headers.get('content-type', ''):
             self.json_body = body
         else:
             self.json_body = None

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -96,7 +96,7 @@ class Request(object):
         #: The parsed JSON from the body.  This value should
         #: only be set if the Content-Type header is application/json,
         #: which is the default content type value in chalice.
-        if self.headers.get('content-type') == 'application/json':
+        if 'application/json' in self.headers.get('content-type'):
             self.json_body = body
         else:
             self.json_body = None

--- a/chalice/local.py
+++ b/chalice/local.py
@@ -72,7 +72,7 @@ class LambdaEventConverter(object):
         if body is None:
             body = '{}'
         json_body = {}  # type: Any
-        if headers.get('content-type', '') == 'application/json':
+        if 'application/json' in headers.get('content-type', ''):
             json_body = json.loads(body)
         base64_body = body.encode('base64')
         return {


### PR DESCRIPTION
Fix for the issue [#180](https://github.com/awslabs/chalice/issues/180) that contains charset in `content-type` header