### PR TITLE
Local development server to log on stdout

### DIFF
--- a/chalice/local.py
+++ b/chalice/local.py
@@ -5,6 +5,8 @@ This is intended only for local development purposes.
 """
 import json
 import functools
+import logging
+import sys
 from collections import namedtuple
 from BaseHTTPServer import HTTPServer
 from BaseHTTPServer import BaseHTTPRequestHandler
@@ -15,6 +17,7 @@ from chalice.app import ChaliceError
 from chalice.app import Chalice  # noqa
 from typing import List, Any, Dict, Tuple, Callable  # noqa
 
+logging.basicConfig(stream=sys.stdout)
 
 MatchResult = namedtuple('MatchResult', ['route', 'captured'])
 EventType = Dict[str, Any]


### PR DESCRIPTION
When running chalice local server, this change would enable the app to log in stdout.

The following code that logs in CloudWatch when running on AWS Lambda, will also work during local.

```
import logging

logger = logging.getLogger()
logger.setLevel(logging.INFO)

@app.route('/')
def index():
    logger.info('Log in stdout when local and in CloudWatch on AWS Lambda')
    return {'hello': 'world'}
```
