### PR TITLE
Fix not all resources being retrieved due to pagination

### DIFF
--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -146,7 +146,13 @@ class TypedAWSClient(object):
     def get_resources_for_api(self, rest_api_id):
         # type: (str) -> List[Dict[str, Any]]
         client = self._client('apigateway')
-        all_resources = client.get_resources(restApiId=rest_api_id)['items']
+        response = client.get_resources(restApiId=rest_api_id, limit=100)
+        all_resources = response['items']
+        while 'position' in response:
+            response = client.get_resources(restApiId=rest_api_id,
+                                            position=response['position'],
+                                            limit=100)
+            all_resources += response['items']
         return all_resources
 
     def delete_methods_from_root_resource(self, rest_api_id, root_resource):

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -74,7 +74,8 @@ def test_get_resources_for_api(stubbed_session):
         'resourceMethods': {},
     }
     stubbed_session.stub('apigateway').get_resources(
-        restApiId='rest_api_id').returns({'items': [expected]})
+        restApiId='rest_api_id',
+        limit=100).returns({'items': [expected]})
     stubbed_session.activate_stubs()
 
     awsclient = TypedAWSClient(stubbed_session)


### PR DESCRIPTION
get_resources by default only retrieves 25 resources per API call, thus
not all resources are returned if the number exceeds this amount.

This adds pagination handling, as well as bumping the limit to 100, such
that less API calls are needed if necessary.