### PR TITLE
add MemorySize support in config and aws client, with tests

### DIFF
--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -44,8 +44,9 @@ class TypedAWSClient(object):
             raise
         return True
 
-    def create_function(self, function_name, role_arn, zip_contents):
-        # type: (str, str, str) -> str
+    def create_function(self, function_name, role_arn, zip_contents,
+                        memory_size):
+        # type: (str, str, str, int) -> str
         kwargs = {
             'FunctionName': function_name,
             'Runtime': 'python2.7',
@@ -53,6 +54,7 @@ class TypedAWSClient(object):
             'Handler': 'app.app',
             'Role': role_arn,
             'Timeout': 60,
+            'MemorySize': memory_size
         }
         client = self._client('lambda')
         attempts = 0
@@ -78,6 +80,11 @@ class TypedAWSClient(object):
         # type: (str, str) -> None
         self._client('lambda').update_function_code(
             FunctionName=function_name, ZipFile=zip_contents)
+
+    def update_function_configuration(self, function_name, memory_size):
+        # type: (str, int) -> None
+        self._client('lambda').update_function_configuration(
+            FunctionName=function_name, MemorySize=memory_size)
 
     def get_role_arn_for_name(self, name):
         # type: (str) -> str

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -88,6 +88,8 @@ class Config(object):
         if result is None:
             return 128
 
+        return result
+
     @property
     def config_from_disk(self):
         # type: () -> StrMap

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -82,6 +82,13 @@ class Config(object):
         return self._chain_lookup('autogen_policy')
 
     @property
+    def memory_size(self):
+        # type: () -> int
+        result = self._chain_lookup('memory_size')
+        if result is None:
+            return 128
+
+    @property
     def config_from_disk(self):
         # type: () -> StrMap
         return self._config_from_disk

--- a/chalice/deployer.py
+++ b/chalice/deployer.py
@@ -651,12 +651,13 @@ class LambdaDeployer(object):
         print "Initial creation of lambda function."
         app_name = config.app_name
         role_arn = self._get_or_create_lambda_role_arn(config)
+        memory_size = config.memory_size
         zip_filename = self._packager.create_deployment_package(
             config.project_dir)
         with open(zip_filename, 'rb') as f:
             zip_contents = f.read()
         return self._aws_client.create_function(
-            app_name, role_arn, zip_contents)
+            app_name, role_arn, zip_contents, memory_size)
 
     def _update_lambda_function(self, config):
         # type: (Config) -> None
@@ -674,6 +675,8 @@ class LambdaDeployer(object):
         zip_contents = self._osutils.get_file_contents(
             deployment_package_filename, binary=True)
         print "Sending changes to lambda."
+        self._aws_client.update_function_configuration(config.app_name,
+                                                       config.memory_size)
         self._aws_client.update_function_code(config.app_name,
                                               zip_contents)
 

--- a/docs/source/topics/configfile.rst
+++ b/docs/source/topics/configfile.rst
@@ -35,3 +35,7 @@ Below are the values you can specify in this file:
   must specify this value that indicates which IAM role arn to
   use when configuration your application.  This value is only
   used if ``manage_iam_role`` is ``false``.
+
+* ``memory_size`` - If ``memory_size`` is set, the lambda function
+  will use this value for its memory size setting. If not set, it
+  will default to 128.

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -51,6 +51,15 @@ def test_update_function_code(stubbed_session):
     stubbed_session.verify_stubs()
 
 
+def test_update_function_configuration(stubbed_session):
+    stubbed_session.stub('lambda').update_function_configuration(
+        FunctionName='name', MemorySize=256).returns({})
+    stubbed_session.activate_stubs()
+    awsclient = TypedAWSClient(stubbed_session)
+    awsclient.update_function_configuration('name', 256)
+    stubbed_session.verify_stubs()
+
+
 def test_put_role_policy(stubbed_session):
     stubbed_session.stub('iam').put_role_policy(
         RoleName='role_name',
@@ -261,11 +270,12 @@ class TestCreateLambdaFunction(object):
             Handler='app.app',
             Role='myarn',
             Timeout=60,
+            MemorySize=128,
         ).returns({'FunctionArn': 'arn:12345:name'})
         stubbed_session.activate_stubs()
         awsclient = TypedAWSClient(stubbed_session)
         assert awsclient.create_function(
-            'name', 'myarn', b'foo') == 'arn:12345:name'
+            'name', 'myarn', b'foo', 128) == 'arn:12345:name'
         stubbed_session.verify_stubs()
 
     def test_create_function_is_retried_and_succeeds(self, stubbed_session):
@@ -276,6 +286,7 @@ class TestCreateLambdaFunction(object):
             'Handler': 'app.app',
             'Role': 'myarn',
             'Timeout': 60,
+            'MemorySize': 128,
         }
         stubbed_session.stub('lambda').create_function(
             **kwargs).raises_error(
@@ -288,7 +299,7 @@ class TestCreateLambdaFunction(object):
         stubbed_session.activate_stubs()
         awsclient = TypedAWSClient(stubbed_session, mock.Mock(spec=time.sleep))
         assert awsclient.create_function(
-            'name', 'myarn', b'foo') == 'arn:12345:name'
+            'name', 'myarn', b'foo', 128) == 'arn:12345:name'
         stubbed_session.verify_stubs()
 
     def test_create_function_fails_after_max_retries(self, stubbed_session):
@@ -299,6 +310,7 @@ class TestCreateLambdaFunction(object):
             'Handler': 'app.app',
             'Role': 'myarn',
             'Timeout': 60,
+            'MemorySize': 128,
         }
         for _ in range(TypedAWSClient.LAMBDA_CREATE_ATTEMPTS):
             stubbed_session.stub('lambda').create_function(
@@ -308,7 +320,7 @@ class TestCreateLambdaFunction(object):
         stubbed_session.activate_stubs()
         awsclient = TypedAWSClient(stubbed_session, mock.Mock(spec=time.sleep))
         with pytest.raises(botocore.exceptions.ClientError):
-            awsclient.create_function('name', 'myarn', b'foo')
+            awsclient.create_function('name', 'myarn', b'foo', 128)
         stubbed_session.verify_stubs()
 
     def test_create_function_propagates_unknown_error(self, stubbed_session):
@@ -319,6 +331,7 @@ class TestCreateLambdaFunction(object):
             'Handler': 'app.app',
             'Role': 'myarn',
             'Timeout': 60,
+            'MemorySize': 128,
         }
         stubbed_session.stub('lambda').create_function(
             **kwargs).raises_error(
@@ -326,7 +339,7 @@ class TestCreateLambdaFunction(object):
         stubbed_session.activate_stubs()
         awsclient = TypedAWSClient(stubbed_session, mock.Mock(spec=time.sleep))
         with pytest.raises(botocore.exceptions.ClientError):
-            awsclient.create_function('name', 'myarn', b'foo')
+            awsclient.create_function('name', 'myarn', b'foo', 128)
         stubbed_session.verify_stubs()
 
 


### PR DESCRIPTION
Referencing #192 to add memory size option in config with 128 default as well as for function create and update. I added a documentation entry that's probably not perfect, but should suffice for now.