### PR TITLE
Add support for more lambda options in config.json and allow config changes between deploys

### DIFF
--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -45,7 +45,7 @@ class TypedAWSClient(object):
         return True
 
     def create_function(self, function_name, role_arn, zip_contents, config):
-        # type: (str, str, str, Dict[str, Any]) -> str
+        # type: (str, str, str, Config) -> str
         kwargs = {
             'FunctionName': function_name,
             'Runtime': 'python2.7',
@@ -81,7 +81,7 @@ class TypedAWSClient(object):
             return response['FunctionArn']
 
     def update_function_configuration(self, function_name, role, config):
-        # type: (str, str, Dict[str, Any]) -> None
+        # type: (str, str, Config) -> None
         kwargs = {
             'FunctionName': function_name,
             'Role': role,

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -56,8 +56,10 @@ class TypedAWSClient(object):
             'MemorySize': 128,
         }
         if config.lambda_config is not None:
-            valid_keys = ['Description','Timeout','MemorySize','VpcConfig','Environment','DeadLetterConfig','KMSKeyArn']
-            [kwargs.update({key:value}) for key, value in config.lambda_config.iteritems() if key in valid_keys]
+            valid_keys = ['Description', 'Timeout', 'MemorySize', 'VpcConfig',
+                          'Environment', 'DeadLetterConfig', 'KMSKeyArn']
+            [kwargs.update({key: value}) for key, value in
+                config.lambda_config.iteritems() if key in valid_keys]
         client = self._client('lambda')
         attempts = 0
         while True:
@@ -79,14 +81,16 @@ class TypedAWSClient(object):
             return response['FunctionArn']
 
     def update_function_configuration(self, function_name, role, config):
-        # type: (str, Dict[str, Any]) -> None
+        # type: (str, str, Dict[str, Any]) -> None
         kwargs = {
             'FunctionName': function_name,
             'Role': role,
         }
         if config.lambda_config is not None:
-            valid_keys = ['Description','Timeout','MemorySize','VpcConfig','Environment','DeadLetterConfig','KMSKeyArn']
-            [kwargs.update({key:value}) for key, value in config.lambda_config.iteritems() if key in valid_keys]
+            valid_keys = ['Description', 'Timeout', 'MemorySize', 'VpcConfig',
+                          'Environment', 'DeadLetterConfig', 'KMSKeyArn']
+            [kwargs.update({key: value}) for key, value in
+                config.lambda_config.iteritems() if key in valid_keys]
         self._client('lambda').update_function_configuration(**kwargs)
 
     def update_function_code(self, function_name, zip_contents):

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -59,7 +59,8 @@ class TypedAWSClient(object):
             valid_keys = ['Description', 'Timeout', 'MemorySize', 'VpcConfig',
                           'Environment', 'DeadLetterConfig', 'KMSKeyArn']
             for key, value in config.lambda_config.iteritems():
-                kwargs.update({key: value}) if key in valid_keys
+                if key in valid_keys:
+                    kwargs.update({key: value})
         client = self._client('lambda')
         attempts = 0
         while True:
@@ -90,7 +91,8 @@ class TypedAWSClient(object):
             valid_keys = ['Description', 'Timeout', 'MemorySize', 'VpcConfig',
                           'Environment', 'DeadLetterConfig', 'KMSKeyArn']
             for key, value in config.lambda_config.iteritems():
-                kwargs.update({key: value}) if key in valid_keys
+                if key in valid_keys:
+                    kwargs.update({key: value})
         self._client('lambda').update_function_configuration(**kwargs)
 
     def update_function_code(self, function_name, zip_contents):

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -45,7 +45,7 @@ class TypedAWSClient(object):
         return True
 
     def create_function(self, function_name, role_arn, zip_contents, config):
-        # type: (str, str, str, Config) -> str
+        # type: (str, str, str, chalice.config.Config) -> str
         kwargs = {
             'FunctionName': function_name,
             'Runtime': 'python2.7',
@@ -81,7 +81,7 @@ class TypedAWSClient(object):
             return response['FunctionArn']
 
     def update_function_configuration(self, function_name, role, config):
-        # type: (str, str, Config) -> None
+        # type: (str, str, chalice.config.Config) -> None
         kwargs = {
             'FunctionName': function_name,
             'Role': role,

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -45,7 +45,7 @@ class TypedAWSClient(object):
         return True
 
     def create_function(self, function_name, role_arn, zip_contents, config):
-        # type: (str, str, str, chalice.config.Config) -> str
+        # type: (str, str, str, Any) -> str
         kwargs = {
             'FunctionName': function_name,
             'Runtime': 'python2.7',
@@ -81,7 +81,7 @@ class TypedAWSClient(object):
             return response['FunctionArn']
 
     def update_function_configuration(self, function_name, role, config):
-        # type: (str, str, chalice.config.Config) -> None
+        # type: (str, str, Any) -> None
         kwargs = {
             'FunctionName': function_name,
             'Role': role,

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -58,8 +58,8 @@ class TypedAWSClient(object):
         if config.lambda_config is not None:
             valid_keys = ['Description', 'Timeout', 'MemorySize', 'VpcConfig',
                           'Environment', 'DeadLetterConfig', 'KMSKeyArn']
-            [kwargs.update({key: value}) for key, value in
-                config.lambda_config.iteritems() if key in valid_keys]
+            for key, value in config.lambda_config.iteritems():
+                kwargs.update({key: value}) if key in valid_keys
         client = self._client('lambda')
         attempts = 0
         while True:
@@ -89,8 +89,8 @@ class TypedAWSClient(object):
         if config.lambda_config is not None:
             valid_keys = ['Description', 'Timeout', 'MemorySize', 'VpcConfig',
                           'Environment', 'DeadLetterConfig', 'KMSKeyArn']
-            [kwargs.update({key: value}) for key, value in
-                config.lambda_config.iteritems() if key in valid_keys]
+            for key, value in config.lambda_config.iteritems():
+                kwargs.update({key: value}) if key in valid_keys
         self._client('lambda').update_function_configuration(**kwargs)
 
     def update_function_code(self, function_name, zip_contents):

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -86,6 +86,11 @@ class Config(object):
         # type: () -> StrMap
         return self._config_from_disk
 
+    @property
+    def lambda_config(self):
+        # type: () -> Dict[str, Any]
+        return self._chain_lookup('lambda')
+
     def _chain_lookup(self, name):
         # type: (str) -> Any
         all_dicts = [

--- a/chalice/deployer.py
+++ b/chalice/deployer.py
@@ -675,7 +675,8 @@ class LambdaDeployer(object):
         zip_contents = self._osutils.get_file_contents(
             deployment_package_filename, binary=True)
         print "Sending changes to lambda."
-        self._aws_client.update_function_configuration(config.app_name, role_arn, config)
+        self._aws_client.update_function_configuration(config.app_name,
+                                                       role_arn, config)
         self._aws_client.update_function_code(config.app_name,
                                               zip_contents)
 

--- a/chalice/deployer.py
+++ b/chalice/deployer.py
@@ -656,11 +656,12 @@ class LambdaDeployer(object):
         with open(zip_filename, 'rb') as f:
             zip_contents = f.read()
         return self._aws_client.create_function(
-            app_name, role_arn, zip_contents)
+            app_name, role_arn, zip_contents, config)
 
     def _update_lambda_function(self, config):
         # type: (Config) -> None
         print "Updating lambda function..."
+        role_arn = self._get_or_create_lambda_role_arn(config)
         project_dir = config.project_dir
         packager = self._packager
         deployment_package_filename = packager.deployment_package_filename(
@@ -674,6 +675,7 @@ class LambdaDeployer(object):
         zip_contents = self._osutils.get_file_contents(
             deployment_package_filename, binary=True)
         print "Sending changes to lambda."
+        self._aws_client.update_function_configuration(config.app_name, role_arn, config)
         self._aws_client.update_function_code(config.app_name,
                                               zip_contents)
 


### PR DESCRIPTION
Updated config to include a `lambda` section that contains boto3 options for create_function and update_function_configuration. I did not write any documentation yet, but if this solution is something that is wanted, I will make the effort to do the documentation.

Ref: #193 PR comments