### PR TITLE
Accept query parameters when running locally

### DIFF
--- a/chalice/local.py
+++ b/chalice/local.py
@@ -5,6 +5,7 @@ This is intended only for local development purposes.
 """
 import json
 import functools
+import urlparse
 from collections import namedtuple
 from BaseHTTPServer import HTTPServer
 from BaseHTTPServer import BaseHTTPRequestHandler
@@ -68,6 +69,12 @@ class LambdaEventConverter(object):
 
     def create_lambda_event(self, method, path, headers, body=None):
         # type: (str, str, Dict[str, str], str) -> EventType
+        if '?' in path:
+            path, querystring = path.split("?")
+            parsed_querystring = dict(urlparse.parse_qsl(querystring))
+        else:
+            parsed_querystring = {}
+
         view_route = self._route_matcher.match_route(path)
         if body is None:
             body = '{}'
@@ -84,7 +91,7 @@ class LambdaEventConverter(object):
             'params': {
                 'header': dict(headers),
                 'path': view_route.captured,
-                'querystring': {},
+                'querystring': parsed_querystring,
             },
             'body-json': json_body,
             'base64-body': base64_body,

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -26,7 +26,11 @@ def sample_app():
 
     @demo.route('/index', methods=['GET'])
     def index():
-        return {'hello': 'world'}
+        name = demo.current_request.query_params.get('name')
+        if name is None:
+            return {'hello': 'world'}
+        else:
+            return {'hello': name}
 
     @demo.route('/names/{name}', methods=['GET'])
     def name(name):
@@ -96,6 +100,10 @@ def test_can_route_url_params(handler):
     assert _get_body_from_response_stream(handler) == {
         'provided-name': 'james'}
 
+def test_can_route_with_query_string(handler):
+    set_current_request(handler, method='GET', path='/index?name=james')
+    handler.do_GET()
+    assert _get_body_from_response_stream(handler) == {'hello': 'james'}
 
 def test_can_route_put_with_body(handler):
     body = '{"foo": "bar"}'


### PR DESCRIPTION
In #196, I  advised that query string parameters do not work when routing locally.

I believe `urlparse.parse_qsl` emulates the behavior of the AWS API Gateway by only accepting the last query value passed if multiple matching keys exist.