### PR TITLE
fix finding root resource if there's multiple existing resources

### DIFF
--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -141,8 +141,9 @@ class TypedAWSClient(object):
 
     def get_root_resource_for_api(self, rest_api_id):
         # type: (str) -> Dict[str, Any]
-        root_resource = self._client('apigateway').get_resources(
-            restApiId=rest_api_id)['items'][0]
+        resources = [r for r in self.get_resources_for_api(rest_api_id)
+                     if r['path'] == '/']
+        root_resource = resources[0]
         return root_resource
 
     def get_resources_for_api(self, rest_api_id):

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -84,7 +84,11 @@ def test_get_resources_for_api(stubbed_session):
 
 
 def test_get_root_resource_for_api(stubbed_session):
-    expected = {
+    root_resource = {
+        'id': 'parentId',
+        'path': '/',
+    }
+    foo_resource = {
         'id': 'id',
         'parentId': 'parentId',
         'pathPart': '/foo',
@@ -92,12 +96,13 @@ def test_get_root_resource_for_api(stubbed_session):
         'resourceMethods': {},
     }
     stubbed_session.stub('apigateway').get_resources(
-        restApiId='rest_api_id').returns({'items': [expected]})
+        restApiId='rest_api_id')\
+        .returns({'items': [foo_resource, root_resource]})
 
     stubbed_session.activate_stubs()
     awsclient = TypedAWSClient(stubbed_session)
     result = awsclient.get_root_resource_for_api('rest_api_id')
-    assert result == expected
+    assert result == root_resource
     stubbed_session.verify_stubs()
 
 


### PR DESCRIPTION
This is the same as #170, but I haven't seen any activity there in a while. This fixes the test, as well as changing it to call `get_resources_for_api` to prevent any pagination issues.

Need this in our deployment as we also non-chalice resources in our API, which causes this function to return the wrong resource.