### PR TITLE
Clean up CLI code

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -348,8 +348,8 @@ def generate_sdk(ctx, sdk_type, outdir):
 
 def run_local_server(app_obj):
     # type: (Chalice) -> None
-    from chalice import local
-    server = local.LocalDevServer(app_obj)
+    from chalice.local import LocalDevServer
+    server = LocalDevServer(app_obj)
     server.serve_forever()
 
 

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -68,11 +68,19 @@ GITIGNORE = """\
 def create_botocore_session(profile=None, debug=False):
     # type: (str, bool) -> botocore.session.Session
     session = botocore.session.Session(profile=profile)
-    session.user_agent_extra = 'chalice/%s' % chalice_version
+    _add_chalice_user_agent(session)
     if debug:
         session.set_debug_logger('')
         inject_large_request_body_filter()
     return session
+
+
+def _add_chalice_user_agent(session):
+    # type: (botocore.session.Session) -> None
+    suffix = '%s/%s' % (session.user_agent_name, session.user_agent_version)
+    session.user_agent_name = 'chalice'
+    session.user_agent_version = chalice_version
+    session.user_agent_extra = suffix
 
 
 def show_lambda_logs(config, max_entries, include_lambda_messages):

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -7,10 +7,7 @@ import os
 import json
 import sys
 import logging
-import zipfile
-import tempfile
 import importlib
-import shutil
 
 import click
 import botocore.exceptions
@@ -322,28 +319,8 @@ def generate_sdk(ctx, sdk_type, outdir):
         click.echo("Could not find API ID, has this application "
                    "been deployed?")
         raise click.Abort()
-    zip_stream = client.get_sdk(rest_api_id, stage=stage_name,
-                                sdk_type=sdk_type)
-    tmpdir = tempfile.mkdtemp()
-    with open(os.path.join(tmpdir, 'sdk.zip'), 'wb') as f:
-        f.write(zip_stream.read())
-    tmp_extract = os.path.join(tmpdir, 'extracted')
-    with zipfile.ZipFile(os.path.join(tmpdir, 'sdk.zip')) as z:
-        z.extractall(tmp_extract)
-    # The extract zip dir will have a single directory:
-    #  ['apiGateway-js-sdk']
-    dirnames = os.listdir(tmp_extract)
-    if len(dirnames) == 1:
-        full_dirname = os.path.join(tmp_extract, dirnames[0])
-        if os.path.isdir(full_dirname):
-            final_dirname = '%s-js-sdk' % config.app_name
-            full_renamed_name = os.path.join(tmp_extract, final_dirname)
-            os.rename(full_dirname, full_renamed_name)
-            shutil.move(full_renamed_name, outdir)
-            return
-    click.echo("The downloaded SDK had an unexpected directory structure: %s"
-               % (', '.join(dirnames)))
-    raise click.Abort()
+    client.download_sdk(rest_api_id, outdir, stage=stage_name,
+                        sdk_type=sdk_type)
 
 
 def run_local_server(app_obj):

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -426,6 +426,7 @@ class TestAddPermissionsForAPIGateway(object):
             sdkType='javascript').returns({'body': 'foo'})
         stubbed_session.activate_stubs()
         awsclient = TypedAWSClient(stubbed_session)
-        response = awsclient.get_sdk('rest-api-id', 'dev', 'javascript')
+        response = awsclient.get_sdk_download_stream(
+            'rest-api-id', 'dev', 'javascript')
         stubbed_session.verify_stubs()
         assert response == 'foo'


### PR DESCRIPTION
Couple of code cleanup and consistency fixes:

* Move the downloading SDK to a directory over to the awsclient.  I want the click functions to be small.
* Don't shadow existing module function name.
* Consistent user agent (matches the pattern boto3/CLI) uses.