### PR TITLE
Supports binary data

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -128,7 +128,7 @@ class RouteEntry(object):
     def __init__(self, view_function, view_name, path, methods,
                  authorization_type=None, authorizer_id=None,
                  api_key_required=None, content_types=None,
-                 cors=False):
+                 cors=False, binary_support=None):
         self.view_function = view_function
         self.view_name = view_name
         self.uri_pattern = path
@@ -141,6 +141,7 @@ class RouteEntry(object):
         self.view_args = self._parse_view_args()
         self.content_types = content_types
         self.cors = cors
+        self.binary_support = binary_support
 
     def _parse_view_args(self):
         if '{' not in self.uri_pattern:
@@ -208,6 +209,7 @@ class Chalice(object):
         api_key_required = kwargs.pop('api_key_required', None)
         content_types = kwargs.pop('content_types', ['application/json'])
         cors = kwargs.pop('cors', False)
+        binary_support = kwargs.pop('binary_support', None)
         if not isinstance(content_types, list):
             raise ValueError('In view function "%s", the content_types '
                              'value must be a list, not %s: %s'
@@ -222,7 +224,7 @@ class Chalice(object):
                 "URL paths must be unique." % path)
         entry = RouteEntry(view_func, name, path, methods, authorization_type,
                            authorizer_id, api_key_required,
-                           content_types, cors)
+                           content_types, cors, binary_support)
         self.routes[path] = entry
 
     def __call__(self, event, context):

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -49,6 +49,7 @@ class RouteEntry(object):
     content_types = ... # type: List[str]
     view_args = ... # type: List[str]
     cors = ... # type: bool
+    binary_support = ... # type: bool
 
     def __init__(self, view_function: Callable[..., Any],
                  view_name: str, path: str, methods: List[str],
@@ -56,7 +57,8 @@ class RouteEntry(object):
                  authorizer_id: str=None,
                  api_key_required: bool=None,
                  content_types: List[str]=None,
-                 cors: bool=False) -> None: ...
+                 cors: bool=False,
+                 binary_support: bool=None) -> None: ...
 
     def _parse_view_args(self) -> List[str]: ...
 

--- a/chalice/deployer.py
+++ b/chalice/deployer.py
@@ -31,8 +31,7 @@ LAMBDA_TRUST_POLICY = {
         "Sid": "",
         "Effect": "Allow",
         "Principal": {
-            "Service": "lambda.amazonaws.com",
-            "Service": "apigateway.amazonaws.com",
+            "Service": "lambda.amazonaws.com"
         },
         "Action": "sts:AssumeRole"}
     ]

--- a/chalice/deployer.py
+++ b/chalice/deployer.py
@@ -31,7 +31,8 @@ LAMBDA_TRUST_POLICY = {
         "Sid": "",
         "Effect": "Allow",
         "Principal": {
-            "Service": "lambda.amazonaws.com"
+            "Service": "lambda.amazonaws.com",
+            "Service": "apigateway.amazonaws.com",
         },
         "Action": "sts:AssumeRole"}
     ]
@@ -47,11 +48,11 @@ CLOUDWATCH_LOGS = {
     "Resource": "arn:aws:logs:*:*:*"
 }
 
-FULL_PASSTHROUGH = """
+BASE_PASSTHROUGH = """
 #set($allParams = $input.params())
 {
 "body-json" : $input.json('$'),
-"base64-body": "$util.base64Encode($input.body)",
+"base64-body": "%(base64Body)s",
 "params" : {
 #foreach($type in $allParams.keySet())
   #set($params = $allParams.get($type))
@@ -99,6 +100,11 @@ FULL_PASSTHROUGH = """
   }
 }
 """
+
+FULL_PASSTHROUGH = BASE_PASSTHROUGH % {
+    "base64Body": "$util.base64Encode($input.body)"
+}
+BINARY_PASSTHROUGH = BASE_PASSTHROUGH % {"base64Body": "$input.body"}
 
 ERROR_MAPPING = (
     "#set($inputRoot = $input.path('$'))"
@@ -303,6 +309,7 @@ class APIGatewayResourceCreator(object):
         # We need to create the parent resource before we can create
         # child resources, so we'll do a pre-order depth first traversal.
         stack = [chalice_trie]
+        binary_media_types = []  # type: List[str]
         while stack:
             current = stack.pop()
             # If there's no resource_id we need to create it.
@@ -324,8 +331,16 @@ class APIGatewayResourceCreator(object):
                 if current['route_entry'].cors:
                     self._apig_methods.create_preflight_method(
                         current['resource_id'], current['route_entry'].methods)
+                if current['route_entry'].binary_support:
+                    content_types = current['route_entry'].content_types
+                    binary_media_types = [
+                        content_type for content_type in content_types
+                        if content_type != 'application/json'
+                    ]
+                    binary_media_types = list(set(binary_media_types))
             for child in current['children']:
                 stack.append(current['children'][child])
+        self._apig_methods.update_binary_media_types(binary_media_types)
         # Add a catch all auth that says anything in this rest API can call
         # the lambda function.
         self.awsclient.add_permission_for_apigateway_if_needed(
@@ -352,7 +367,7 @@ class APIGatewayResourceCreator(object):
         )
         self._apig_methods.create_lambda_method_integration(
             resource_id, http_method, route_entry.content_types,
-            self._lambda_uri()
+            self._lambda_uri(), route_entry.binary_support
         )
         self._apig_methods.create_method_response(
             resource_id, http_method, route_entry.cors)
@@ -922,24 +937,40 @@ class APIGatewayMethods(object):
         self._apig_client.put_method(**put_method_cfg)
 
     def create_lambda_method_integration(self, resource_id, http_method,
-                                         content_types, lambda_uri):
-        # type: (str, str, List[str], str) -> None
+                                         content_types, lambda_uri,
+                                         binary_support=None):
+        # type: (str, str, List[str], str, bool) -> None
         """Create an integration method for AWS Lambda."""
-        self._apig_client.put_integration(
-            restApiId=self.rest_api_id,
-            resourceId=resource_id,
-            type='AWS',
-            httpMethod=http_method,
-            integrationHttpMethod='POST',
-            # Request body will never be passed through to
-            # the integration, if the Content-Type header
-            # is not application/json.
-            passthroughBehavior="NEVER",
-            requestTemplates={
-                key: FULL_PASSTHROUGH for key in content_types
-            },
-            uri=lambda_uri,
-        )
+        if binary_support is None:
+            self._apig_client.put_integration(
+                restApiId=self.rest_api_id,
+                resourceId=resource_id,
+                type='AWS',
+                httpMethod=http_method,
+                integrationHttpMethod='POST',
+                # Request body will never be passed through to
+                # the integration, if the Content-Type header
+                # is not application/json.
+                passthroughBehavior='NEVER',
+                requestTemplates={
+                    key: FULL_PASSTHROUGH for key in content_types
+                },
+                uri=lambda_uri,
+            )
+        else:
+            self._apig_client.put_integration(
+                restApiId=self.rest_api_id,
+                resourceId=resource_id,
+                type='AWS',
+                httpMethod=http_method,
+                integrationHttpMethod='POST',
+                passthroughBehavior='WHEN_NO_TEMPLATES',
+                requestTemplates={
+                    key: BINARY_PASSTHROUGH for key in content_types
+                },
+                contentHandling="CONVERT_TO_TEXT",
+                uri=lambda_uri,
+            )
 
     def create_method_response(self, resource_id, http_method, cors=False):
         # type: (str, str, bool) -> None
@@ -1057,4 +1088,32 @@ class APIGatewayMethods(object):
                     "'Content-Type,X-Amz-Date,Authorization,X-Api-Key"
                     ",X-Amz-Security-Token'")
             },
+        )
+
+    def update_binary_media_types(self, binary_media_types):
+        # type: (List[str]) -> None
+        patch_operations = []
+        response = self._apig_client.get_rest_api(restApiId=self.rest_api_id)
+        for content_type in response.get('binary_media_types', []):
+            patch_operations.append({
+                'op': 'remove',
+                'path': "%s" % content_type
+            })
+        if patch_operations:
+            self._patch_operations(patch_operations)
+        patch_operations = []
+        for content_type in binary_media_types:
+            patch_operations.append({
+                'op': 'add',
+                'path': '/binaryMediaTypes/{}'.format(
+                    content_type.replace('/', '~1'))
+            })
+        if patch_operations:
+            self._patch_operations(patch_operations)
+
+    def _patch_operations(self, patch_operations):
+        # type: (List[dict]) -> None
+        self._apig_client.update_rest_api(
+            restApiId=self.rest_api_id,
+            patchOperations=patch_operations
         )

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -440,3 +440,19 @@ def test_json_body_available_when_content_type_matches(content_type, is_json):
         assert request.json_body == {'json': 'body'}
     else:
         assert request.json_body is None
+
+
+def test_binary_body():
+    demo = app.Chalice('app-name')
+
+    @demo.route('/index', methods=['POST'],
+            content_types=['application/octet-stream'], binary_support=True)
+    def index_view():
+        return {'rawbody': demo.current_request.raw_body}
+
+
+    event = create_event('/index', 'POST', {})
+    event['base64-body'] = base64.b64encode('\xFF\xFF')
+
+    result = demo(event, context=None)
+    assert result == {'rawbody': '\xFF\xFF'}


### PR DESCRIPTION
This will support binary data.

```
@app.route('/upload', methods=['POST'],
        content_types=['application/octet-stream'],
        binary_support=True)
def upload:
    # Body is binary data.
    body = app.current_request.raw_body
    # Use boto3 s3 client
    s3.put_object(
        Bucket=S3_BUCKET,
        Key=KEY,
        Body=body,
        ContentType='application/octet-stream'
    )
    return {}
```
https://aws.amazon.com/jp/about-aws/whats-new/2016/11/binary-data-now-supported-by-api-gateway/