### PR TITLE
Upgrade type and click versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,10 @@ with open('README.rst') as readme_file:
 
 
 install_requires = [
-    'click==6.2',
+    'click==6.6',
     'botocore>=1.4.8,<2.0.0',
     'virtualenv>=15.0.0,<16.0.0',
-    'typing==3.5.2.2',
+    'typing==3.5.3.0',
 ]
 
 


### PR DESCRIPTION
typing==3.5.3.0
click==6.6

>I've released typing 3.5.3.0 -- the typing package as distributed with Python 3.6.0, for use in 2.7 and 3.2--3.4. https://pypi.python.org/pypi?name=typing&version=3.5.3.0&:action=display …

https://twitter.com/gvanrossum/status/815395496395051008
