### PR TITLE
Generate debug.py file to debug application with breakpoints.

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -60,7 +60,18 @@ GITIGNORE = """\
 .chalice/deployments/
 .chalice/venv/
 """
+DEBUGGING = """\
+from click.testing import CliRunner
+from chalice import cli
+import os
 
+project_dir = os.getcwd()
+obj = dict()
+obj['project_dir'] = project_dir
+
+runner = CliRunner()
+result = runner.invoke(cli.local, obj=obj)
+"""
 
 def create_botocore_session(profile=None, debug=False):
     # type: (str, bool) -> botocore.session.Session
@@ -283,6 +294,8 @@ def new_project(project_name, profile):
         f.write(TEMPLATE_APP % project_name)
     with open(os.path.join(project_name, '.gitignore'), 'w') as f:
         f.write(GITIGNORE)
+    with open(os.path.join(project_name, 'debug.py'), 'w') as f:
+        f.write(DEBUGGING)
 
 
 @cli.command('url')

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -73,6 +73,7 @@ runner = CliRunner()
 result = runner.invoke(cli.local, obj=obj)
 """
 
+
 def create_botocore_session(profile=None, debug=False):
     # type: (str, bool) -> botocore.session.Session
     session = botocore.session.Session(profile=profile)


### PR DESCRIPTION
While creating a new project using `chalice new-project` a `debug.py` file will be generated. 

In Eclipse IDE with PyDev, right click the `debug.py` file select `Debug As -> Python Run` to run the chalice app in local mode with debuggers attached. Further, add breakpoints as required to debug.

Proposing this PR for #215