### PR TITLE
Add --single-file to package command

### DIFF
--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -16,11 +16,10 @@ def create_zip_file(source_dir, outfile):
     """
     with zipfile.ZipFile(outfile, 'w',
                          compression=zipfile.ZIP_DEFLATED) as z:
-        prefix_len = len(source_dir) + 1
         for root, _, filenames in os.walk(source_dir):
             for filename in filenames:
                 full_name = os.path.join(root, filename)
-                archive_name = full_name[prefix_len:]
+                archive_name = os.path.relpath(full_name, source_dir)
                 z.write(full_name, archive_name)
 
 

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -1,6 +1,27 @@
 import os
+import zipfile
 
 from typing import IO  # noqa
+
+
+def create_zip_file(source_dir, outfile):
+    # type: (str, str) -> None
+    """Create a zip file from a source input directory.
+
+    This function is intended to be an equivalent to
+    `zip -r`.  You give it a source directory, `source_dir`,
+    and it will recursively zip up the files into a zipfile
+    specified by the `outfile` argument.
+
+    """
+    with zipfile.ZipFile(outfile, 'w',
+                         compression=zipfile.ZIP_DEFLATED) as z:
+        prefix_len = len(source_dir) + 1
+        for root, _, filenames in os.walk(source_dir):
+            for filename in filenames:
+                full_name = os.path.join(root, filename)
+                archive_name = full_name[prefix_len:]
+                z.write(full_name, archive_name)
 
 
 class OSUtils(object):

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -1,0 +1,37 @@
+import zipfile
+
+from chalice import utils
+
+
+def test_can_zip_single_file(tmpdir):
+    source = tmpdir.mkdir('sourcedir')
+    source.join('hello.txt').write('hello world')
+    outfile = str(tmpdir.join('out.zip'))
+    utils.create_zip_file(source_dir=str(source),
+                          outfile=outfile)
+    with zipfile.ZipFile(outfile) as f:
+        contents = f.read('hello.txt')
+        assert contents == 'hello world'
+        assert f.namelist() == ['hello.txt']
+
+
+def test_can_zip_recursive_contents(tmpdir):
+    source = tmpdir.mkdir('sourcedir')
+    source.join('hello.txt').write('hello world')
+    subdir = source.mkdir('subdir')
+    subdir.join('sub.txt').write('sub.txt')
+    subdir.join('sub2.txt').write('sub2.txt')
+    subsubdir = subdir.mkdir('subsubdir')
+    subsubdir.join('leaf.txt').write('leaf.txt')
+
+    outfile = str(tmpdir.join('out.zip'))
+    utils.create_zip_file(source_dir=str(source),
+                          outfile=outfile)
+    with zipfile.ZipFile(outfile) as f:
+        assert f.namelist() == [
+            'hello.txt',
+            'subdir/sub.txt',
+            'subdir/sub2.txt',
+            'subdir/subsubdir/leaf.txt',
+        ]
+        assert f.read('subdir/subsubdir/leaf.txt') == 'leaf.txt'


### PR DESCRIPTION
This allows the package command to produce
a single file for all the packaged assets instead
of an output directory.