### PR TITLE
Introduce completely separate chalice stages

### DIFF
--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -20,8 +20,7 @@ import zipfile
 import shutil
 import json
 
-import botocore.session
-import botocore.exceptions
+import botocore.session  # noqa
 from typing import Any, Optional, Dict, Callable, List  # noqa
 
 
@@ -40,14 +39,12 @@ class TypedAWSClient(object):
 
     def lambda_function_exists(self, name):
         # type: (str) -> bool
+        client = self._client('lambda')
         try:
-            self._client('lambda').get_function(FunctionName=name)
-        except botocore.exceptions.ClientError as e:
-            error = e.response['Error']
-            if error['Code'] == 'ResourceNotFoundException':
-                return False
-            raise
-        return True
+            client.get_function(FunctionName=name)
+            return True
+        except client.exceptions.ResourceNotFoundException:
+            return False
 
     def create_function(self, function_name, role_arn, zip_contents):
         # type: (str, str, str) -> str
@@ -64,19 +61,16 @@ class TypedAWSClient(object):
         while True:
             try:
                 response = client.create_function(**kwargs)
-            except botocore.exceptions.ClientError as e:
-                code = e.response['Error'].get('Code')
-                if code == 'InvalidParameterValueException':
-                    # We're assuming that if we receive an
-                    # InvalidParameterValueException, it's because
-                    # the role we just created can't be used by
-                    # Lambda.
-                    self._sleep(self.DELAY_TIME)
-                    attempts += 1
-                    if attempts >= self.LAMBDA_CREATE_ATTEMPTS:
-                        raise
-                    continue
-                raise
+            except client.exceptions.InvalidParameterValueException:
+                # We're assuming that if we receive an
+                # InvalidParameterValueException, it's because
+                # the role we just created can't be used by
+                # Lambda.
+                self._sleep(self.DELAY_TIME)
+                attempts += 1
+                if attempts >= self.LAMBDA_CREATE_ATTEMPTS:
+                    raise
+                continue
             return response['FunctionArn']
 
     def update_function_code(self, function_name, zip_contents):
@@ -86,13 +80,11 @@ class TypedAWSClient(object):
 
     def get_role_arn_for_name(self, name):
         # type: (str) -> str
+        client = self._client('iam')
         try:
-            role = self._client('iam').get_role(RoleName=name)
-        except botocore.exceptions.ClientError as e:
-            error = e.response['Error']
-            if error['Code'] == 'NoSuchEntity':
-                raise ValueError("No role ARN found for: %s" % name)
-            raise
+            role = client.get_role(RoleName=name)
+        except client.exceptions.NoSuchEntityException:
+            raise ValueError("No role ARN found for: %s" % name)
         return role['Role']['Arn']
 
     def delete_role_policy(self, role_name, policy_name):
@@ -141,13 +133,12 @@ class TypedAWSClient(object):
     def rest_api_exists(self, rest_api_id):
         # type: (str) -> bool
         """Check if an an API Gateway REST API exists."""
+        client = self._client('apigateway')
         try:
-            self._client('apigateway').get_rest_api(restApiId=rest_api_id)
+            client.get_rest_api(restApiId=rest_api_id)
             return True
-        except botocore.exceptions.ClientError as e:
-            if e['Code'] == 'NotFoundException':
-                return False
-            raise
+        except client.exceptions.NotFoundException:
+            return False
 
     def import_rest_api(self, swagger_document):
         # type: (Dict[str, Any]) -> str
@@ -185,12 +176,11 @@ class TypedAWSClient(object):
 
         """
         has_necessary_permissions = False
+        client = self._client('lambda')
         try:
             policy = self.get_function_policy(function_name)
-        except botocore.exceptions.ClientError as e:
-            error = e.response['Error']
-            if error['Code'] == 'ResourceNotFoundException':
-                pass
+        except client.exceptions.ResourceNotFoundException:
+            pass
         else:
             source_arn = self._build_source_arn_str(region_name, account_id,
                                                     rest_api_id)

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -80,8 +80,8 @@ class TypedAWSClient(object):
             return response['FunctionArn']
 
     def update_function_code(self, function_name, zip_contents):
-        # type: (str, str) -> None
-        self._client('lambda').update_function_code(
+        # type: (str, str) -> Dict[str, Any]
+        return self._client('lambda').update_function_code(
             FunctionName=function_name, ZipFile=zip_contents)
 
     def get_role_arn_for_name(self, name):
@@ -137,6 +137,17 @@ class TypedAWSClient(object):
             if api['name'] == name:
                 return api['id']
         return None
+
+    def rest_api_exists(self, rest_api_id):
+        # type: (str) -> bool
+        """Check if an an API Gateway REST API exists."""
+        try:
+            self._client('apigateway').get_rest_api(restApiId=rest_api_id)
+            return True
+        except botocore.exceptions.ClientError as e:
+            if e['Code'] == 'NotFoundException':
+                return False
+            raise
 
     def import_rest_api(self, swagger_document):
         # type: (Dict[str, Any]) -> str

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -8,12 +8,13 @@ import os
 import uuid
 
 import botocore.session  # noqa
-from typing import Any, Tuple, Callable, List, Dict  # noqa
+from typing import Any, Tuple, Callable, List, Dict, Optional  # noqa
 
 from chalice import app  # noqa
+from chalice import __version__ as chalice_version
 from chalice import policy
 from chalice.awsclient import TypedAWSClient
-from chalice.config import Config  # noqa
+from chalice.config import Config, DeployedResources  # noqa
 from chalice.deploy.packager import LambdaDeploymentPackager
 from chalice.deploy.swagger import SwaggerGenerator
 from chalice.utils import OSUtils
@@ -132,16 +133,19 @@ class NoPrompt(object):
 
 
 class Deployer(object):
+
+    BACKEND_NAME = 'api'
+
     def __init__(self, apigateway_deploy, lambda_deploy):
         # type: (APIGatewayDeployer, LambdaDeployer) -> None
         self._apigateway_deploy = apigateway_deploy
         self._lambda_deploy = lambda_deploy
 
-    def deploy(self, config):
-        # type: (Config) -> Tuple[str, str, str]
+    def deploy(self, config, stage_name='dev'):
+        # type: (Config, str) -> Dict[str, Any]
         """Deploy chalice application to AWS.
 
-        :type config: dict
+        :type config: Config
         :param config: A dictionary of config values including:
 
             * project_dir - The directory containing the project
@@ -150,14 +154,218 @@ class Deployer(object):
 
         """
         validate_configuration(config)
-        self._lambda_deploy.deploy(config)
-        rest_api_id, region_name, stage = self._apigateway_deploy.deploy(
-            config)
+        existing_resources = config.deployed_resources(stage_name)
+        deployed_values = self._lambda_deploy.deploy(
+            config, existing_resources, stage_name)
+        rest_api_id, region_name, apig_stage = self._apigateway_deploy.deploy(
+            config, existing_resources)
         print (
             "https://{api_id}.execute-api.{region}.amazonaws.com/{stage}/"
-            .format(api_id=rest_api_id, region=region_name, stage=stage)
+            .format(api_id=rest_api_id, region=region_name, stage=apig_stage)
         )
-        return rest_api_id, region_name, stage
+        deployed_values.update({
+            'rest_api_id': rest_api_id,
+            'region': region_name,
+            'api_gateway_stage': apig_stage,
+            'backend': self.BACKEND_NAME,
+            'chalice_version': chalice_version,
+        })
+        return {
+            stage_name: deployed_values
+        }
+
+
+class LambdaDeployer(object):
+    def __init__(self,
+                 aws_client,   # type: TypedAWSClient
+                 packager,     # type: LambdaDeploymentPackager
+                 prompter,     # type: NoPrompt
+                 osutils,      # type: OSUtils
+                 app_policy,   # type: ApplicationPolicyHandler
+                 ):
+        # type: (...) -> None
+        self._aws_client = aws_client
+        self._packager = packager
+        self._prompter = prompter
+        self._osutils = osutils
+        self._app_policy = app_policy
+
+    def deploy(self, config, existing_resources, stage_name):
+        # type: (Config, Optional[DeployedResources], str) -> Dict[str, str]
+        function_name = '%s-%s' % (config.app_name, stage_name)
+        deployed_values = {'api_handler_name': function_name}
+        if existing_resources is not None and \
+                self._aws_client.lambda_function_exists(
+                    existing_resources.api_handler_name):
+            self._get_or_create_lambda_role_arn(
+                config, existing_resources.api_handler_name)
+            self._update_lambda_function(
+                config, existing_resources.api_handler_name)
+            function_arn = existing_resources.api_handler_arn
+        else:
+            function_arn = self._first_time_lambda_create(
+                config, function_name)
+            # Record the lambda_arn for later use.
+            config.config_from_disk['lambda_arn'] = function_arn
+            self._write_config_to_disk(config)
+        deployed_values['api_handler_arn'] = function_arn
+        return deployed_values
+
+    def _get_or_create_lambda_role_arn(self, config, role_name):
+        # type: (Config, str) -> str
+        if not config.manage_iam_role:
+            # We've already validated the config, so we know
+            # if manage_iam_role==False, then they've provided a
+            # an iam_role_arn.
+            return config.iam_role_arn
+
+        try:
+            # We're using the lambda function_name as the role_name.
+            role_arn = self._aws_client.get_role_arn_for_name(role_name)
+            self._update_role_with_latest_policy(role_name, config)
+        except ValueError:
+            print "Creating role"
+            role_arn = self._create_role_from_source_code(config, role_name)
+        return role_arn
+
+    def _update_role_with_latest_policy(self, app_name, config):
+        # type: (str, Config) -> None
+        print "Updating IAM policy."
+        app_policy = self._app_policy.generate_policy_from_app_source(
+            config.project_dir, config.autogen_policy)
+        previous = self._app_policy.load_last_policy(config.project_dir)
+        diff = policy.diff_policies(previous, app_policy)
+        if diff:
+            if diff.get('added', set([])):
+                print ("\nThe following actions will be added to "
+                       "the execution policy:\n")
+                for action in diff['added']:
+                    print action
+            if diff.get('removed', set([])):
+                print ("\nThe following action will be removed from "
+                       "the execution policy:\n")
+                for action in diff['removed']:
+                    print action
+            self._prompter.confirm("\nWould you like to continue? ",
+                                   default=True, abort=True)
+        self._aws_client.delete_role_policy(
+            role_name=app_name, policy_name=app_name)
+        self._aws_client.put_role_policy(role_name=app_name,
+                                         policy_name=app_name,
+                                         policy_document=app_policy)
+        self._app_policy.record_policy(config.project_dir, app_policy)
+
+    def _first_time_lambda_create(self, config, function_name):
+        # type: (Config, str) -> str
+        # Creates a lambda function and returns the
+        # function arn.
+        # First we need to create a deployment package.
+        print "Initial creation of lambda function."
+        role_arn = self._get_or_create_lambda_role_arn(config, function_name)
+        zip_filename = self._packager.create_deployment_package(
+            config.project_dir)
+        with open(zip_filename, 'rb') as f:
+            zip_contents = f.read()
+        return self._aws_client.create_function(
+            function_name, role_arn, zip_contents)
+
+    def _update_lambda_function(self, config, lambda_name):
+        # type: (Config, str) -> None
+        print "Updating lambda function..."
+        project_dir = config.project_dir
+        packager = self._packager
+        deployment_package_filename = packager.deployment_package_filename(
+            project_dir)
+        if self._osutils.file_exists(deployment_package_filename):
+            packager.inject_latest_app(deployment_package_filename,
+                                       project_dir)
+        else:
+            deployment_package_filename = packager.create_deployment_package(
+                project_dir)
+        zip_contents = self._osutils.get_file_contents(
+            deployment_package_filename, binary=True)
+        print "Sending changes to lambda."
+        self._aws_client.update_function_code(lambda_name, zip_contents)
+
+    def _write_config_to_disk(self, config):
+        # type: (Config) -> None
+        config_filename = os.path.join(config.project_dir,
+                                       '.chalice', 'config.json')
+        with open(config_filename, 'w') as f:
+            f.write(json.dumps(config.config_from_disk, indent=2))
+
+    def _create_role_from_source_code(self, config, role_name):
+        # type: (Config, str) -> str
+        app_policy = self._app_policy.generate_policy_from_app_source(
+            config.project_dir, config.autogen_policy)
+        if len(app_policy['Statement']) > 1:
+            print "The following execution policy will be used:"
+            print json.dumps(app_policy, indent=2)
+            self._prompter.confirm("Would you like to continue? ",
+                                   default=True, abort=True)
+        role_arn = self._aws_client.create_role(
+            name=role_name,
+            trust_policy=LAMBDA_TRUST_POLICY,
+            policy=app_policy
+        )
+        self._app_policy.record_policy(config.project_dir, app_policy)
+        return role_arn
+
+
+class APIGatewayDeployer(object):
+    def __init__(self, aws_client):
+        # type: (TypedAWSClient) -> None
+        self._aws_client = aws_client
+
+    def deploy(self, config, existing_resources):
+        # type: (Config, Optional[DeployedResources]) -> Tuple[str, str, str]
+        if existing_resources is not None and \
+                self._aws_client.rest_api_exists(
+                    existing_resources.rest_api_id):
+            print "API Gateway rest API already found."
+            rest_api_id = existing_resources.rest_api_id
+            return self._create_resources_for_api(config, rest_api_id)
+        else:
+            print "Initiating first time deployment..."
+            return self._first_time_deploy(config)
+
+    def _first_time_deploy(self, config):
+        # type: (Config) -> Tuple[str, str, str]
+        generator = SwaggerGenerator(self._aws_client.region_name,
+                                     config.lambda_arn)
+        swagger_doc = generator.generate_swagger(config.chalice_app)
+        # The swagger_doc that's generated will contain the "name" which is
+        # used to set the name for the restAPI.  API Gateway allows you
+        # to have multiple restAPIs with the same name, they'll have
+        # different restAPI ids.  It might be worth creating unique names
+        # for each rest API, but that would require injecting chalice stage
+        # information into the swagger generator.
+        rest_api_id = self._aws_client.import_rest_api(swagger_doc)
+        stage = config.stage or 'dev'
+        self._deploy_api_to_stage(rest_api_id, stage, config)
+        return rest_api_id, self._aws_client.region_name, stage
+
+    def _create_resources_for_api(self, config, rest_api_id):
+        # type: (Config, str) -> Tuple[str, str, str]
+        generator = SwaggerGenerator(self._aws_client.region_name,
+                                     config.lambda_arn)
+        swagger_doc = generator.generate_swagger(config.chalice_app)
+        self._aws_client.update_api_from_swagger(rest_api_id, swagger_doc)
+        stage = config.stage or 'dev'
+        self._deploy_api_to_stage(rest_api_id, stage, config)
+        return rest_api_id, self._aws_client.region_name, stage
+
+    def _deploy_api_to_stage(self, rest_api_id, stage, config):
+        # type: (str, str, Config) -> None
+        print "Deploying to:", stage
+        self._aws_client.deploy_rest_api(rest_api_id, stage)
+        self._aws_client.add_permission_for_apigateway_if_needed(
+            config.lambda_arn.split(':')[-1],
+            self._aws_client.region_name,
+            config.lambda_arn.split(':')[4],
+            rest_api_id,
+            str(uuid.uuid4()),
+        )
 
 
 class ApplicationPolicyHandler(object):
@@ -227,184 +435,3 @@ class ApplicationPolicyHandler(object):
         # type: (str) -> str
         policy_file = os.path.join(project_dir, '.chalice', 'policy.json')
         return policy_file
-
-
-class LambdaDeployer(object):
-    def __init__(self,
-                 aws_client,   # type: TypedAWSClient
-                 packager,     # type: LambdaDeploymentPackager
-                 prompter,     # type: NoPrompt
-                 osutils,      # type: OSUtils
-                 app_policy,   # type: ApplicationPolicyHandler
-                 ):
-        # type: (...) -> None
-        self._aws_client = aws_client
-        self._packager = packager
-        self._prompter = prompter
-        self._osutils = osutils
-        self._app_policy = app_policy
-
-    def deploy(self, config):
-        # type: (Config) -> None
-        app_name = config.app_name
-        if self._aws_client.lambda_function_exists(app_name):
-            self._get_or_create_lambda_role_arn(config)
-            self._update_lambda_function(config)
-        else:
-            function_arn = self._first_time_lambda_create(config)
-            # Record the lambda_arn for later use.
-            config.config_from_disk['lambda_arn'] = function_arn
-            self._write_config_to_disk(config)
-        print "Lambda deploy done."
-
-    def _get_or_create_lambda_role_arn(self, config):
-        # type: (Config) -> str
-        if not config.manage_iam_role:
-            # We've already validated the config, so we know
-            # if manage_iam_role==False, then they've provided a
-            # an iam_role_arn.
-            return config.iam_role_arn
-
-        app_name = config.app_name
-        try:
-            role_arn = self._aws_client.get_role_arn_for_name(app_name)
-            self._update_role_with_latest_policy(app_name, config)
-        except ValueError:
-            print "Creating role"
-            role_arn = self._create_role_from_source_code(config)
-        return role_arn
-
-    def _update_role_with_latest_policy(self, app_name, config):
-        # type: (str, Config) -> None
-        print "Updating IAM policy."
-        app_policy = self._app_policy.generate_policy_from_app_source(
-            config.project_dir, config.autogen_policy)
-        previous = self._app_policy.load_last_policy(config.project_dir)
-        diff = policy.diff_policies(previous, app_policy)
-        if diff:
-            if diff.get('added', set([])):
-                print ("\nThe following actions will be added to "
-                       "the execution policy:\n")
-                for action in diff['added']:
-                    print action
-            if diff.get('removed', set([])):
-                print ("\nThe following action will be removed from "
-                       "the execution policy:\n")
-                for action in diff['removed']:
-                    print action
-            self._prompter.confirm("\nWould you like to continue? ",
-                                   default=True, abort=True)
-        self._aws_client.delete_role_policy(
-            role_name=app_name, policy_name=app_name)
-        self._aws_client.put_role_policy(role_name=app_name,
-                                         policy_name=app_name,
-                                         policy_document=app_policy)
-        self._app_policy.record_policy(config.project_dir, app_policy)
-
-    def _first_time_lambda_create(self, config):
-        # type: (Config) -> str
-        # Creates a lambda function and returns the
-        # function arn.
-        # First we need to create a deployment package.
-        print "Initial creation of lambda function."
-        app_name = config.app_name
-        role_arn = self._get_or_create_lambda_role_arn(config)
-        zip_filename = self._packager.create_deployment_package(
-            config.project_dir)
-        with open(zip_filename, 'rb') as f:
-            zip_contents = f.read()
-        return self._aws_client.create_function(
-            app_name, role_arn, zip_contents)
-
-    def _update_lambda_function(self, config):
-        # type: (Config) -> None
-        print "Updating lambda function..."
-        project_dir = config.project_dir
-        packager = self._packager
-        deployment_package_filename = packager.deployment_package_filename(
-            project_dir)
-        if self._osutils.file_exists(deployment_package_filename):
-            packager.inject_latest_app(deployment_package_filename,
-                                       project_dir)
-        else:
-            deployment_package_filename = packager.create_deployment_package(
-                project_dir)
-        zip_contents = self._osutils.get_file_contents(
-            deployment_package_filename, binary=True)
-        print "Sending changes to lambda."
-        self._aws_client.update_function_code(config.app_name,
-                                              zip_contents)
-
-    def _write_config_to_disk(self, config):
-        # type: (Config) -> None
-        config_filename = os.path.join(config.project_dir,
-                                       '.chalice', 'config.json')
-        with open(config_filename, 'w') as f:
-            f.write(json.dumps(config.config_from_disk, indent=2))
-
-    def _create_role_from_source_code(self, config):
-        # type: (Config) -> str
-        app_name = config.app_name
-        app_policy = self._app_policy.generate_policy_from_app_source(
-            config.project_dir, config.autogen_policy)
-        if len(app_policy['Statement']) > 1:
-            print "The following execution policy will be used:"
-            print json.dumps(app_policy, indent=2)
-            self._prompter.confirm("Would you like to continue? ",
-                                   default=True, abort=True)
-        role_arn = self._aws_client.create_role(
-            name=app_name,
-            trust_policy=LAMBDA_TRUST_POLICY,
-            policy=app_policy
-        )
-        self._app_policy.record_policy(config.project_dir, app_policy)
-        return role_arn
-
-
-class APIGatewayDeployer(object):
-    def __init__(self, aws_client):
-        # type: (TypedAWSClient) -> None
-        self._aws_client = aws_client
-
-    def deploy(self, config):
-        # type: (Config) -> Tuple[str, str, str]
-        app_name = config.app_name
-        rest_api_id = self._aws_client.get_rest_api_id(app_name)
-        if rest_api_id is None:
-            print "Initiating first time deployment..."
-            return self._first_time_deploy(config)
-        else:
-            print "API Gateway rest API already found."
-            return self._create_resources_for_api(config, rest_api_id)
-
-    def _first_time_deploy(self, config):
-        # type: (Config) -> Tuple[str, str, str]
-        generator = SwaggerGenerator(self._aws_client.region_name,
-                                     config.lambda_arn)
-        swagger_doc = generator.generate_swagger(config.chalice_app)
-        rest_api_id = self._aws_client.import_rest_api(swagger_doc)
-        stage = config.stage or 'dev'
-        self._deploy_api_to_stage(rest_api_id, stage, config)
-        return rest_api_id, self._aws_client.region_name, stage
-
-    def _create_resources_for_api(self, config, rest_api_id):
-        # type: (Config, str) -> Tuple[str, str, str]
-        generator = SwaggerGenerator(self._aws_client.region_name,
-                                     config.lambda_arn)
-        swagger_doc = generator.generate_swagger(config.chalice_app)
-        self._aws_client.update_api_from_swagger(rest_api_id, swagger_doc)
-        stage = config.stage or 'dev'
-        self._deploy_api_to_stage(rest_api_id, stage, config)
-        return rest_api_id, self._aws_client.region_name, stage
-
-    def _deploy_api_to_stage(self, rest_api_id, stage, config):
-        # type: (str, str, Config) -> None
-        print "Deploying to:", stage
-        self._aws_client.deploy_rest_api(rest_api_id, stage)
-        self._aws_client.add_permission_for_apigateway_if_needed(
-            config.lambda_arn.split(':')[-1],
-            self._aws_client.region_name,
-            config.lambda_arn.split(':')[4],
-            rest_api_id,
-            str(uuid.uuid4()),
-        )

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -1,7 +1,24 @@
 import os
 import zipfile
+import json
 
-from typing import IO  # noqa
+from typing import IO, Dict, Any  # noqa
+
+
+def record_deployed_values(deployed_values, filename):
+    # type: (Dict[str, str], str) -> None
+    """Record deployed values to a JSON file.
+
+    This allows subsequent deploys to lookup previously deployed values.
+
+    """
+    final_values = {}  # type: Dict[str, Any]
+    if os.path.isfile(filename):
+        with open(filename, 'r') as f:
+            final_values = json.load(f)
+    final_values.update(deployed_values)
+    with open(filename, 'wb') as f:
+        f.write(json.dumps(final_values, indent=2, separators=(',', ': ')))
 
 
 def create_zip_file(source_dir, outfile):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.rst') as readme_file:
 
 install_requires = [
     'click==6.6',
-    'botocore>=1.4.8,<2.0.0',
+    'botocore>=1.5.0,<2.0.0',
     'virtualenv>=15.0.0,<16.0.0',
     'typing==3.5.3.0',
 ]

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -47,6 +47,30 @@ def test_put_role_policy(stubbed_session):
     stubbed_session.verify_stubs()
 
 
+def test_rest_api_exists(stubbed_session):
+    stubbed_session.stub('apigateway').get_rest_api(
+        restApiId='api').returns({})
+    stubbed_session.activate_stubs()
+
+    awsclient = TypedAWSClient(stubbed_session)
+    assert awsclient.rest_api_exists('api')
+
+    stubbed_session.verify_stubs()
+
+
+def test_rest_api_not_exists(stubbed_session):
+    stubbed_session.stub('apigateway').get_rest_api(
+        restApiId='api').raises_error(
+            error_code='NotFoundException',
+            message='ResourceNotFound')
+    stubbed_session.activate_stubs()
+
+    awsclient = TypedAWSClient(stubbed_session)
+    assert not awsclient.rest_api_exists('api')
+
+    stubbed_session.verify_stubs()
+
+
 class TestLambdaFunctionExists(object):
 
     def test_can_query_lambda_function_exists(self, stubbed_session):

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -40,6 +40,19 @@ def test_can_zip_recursive_contents(tmpdir):
 
 def test_can_write_recorded_values(tmpdir):
     filename = str(tmpdir.join('deployed.json'))
-    utils.record_deployed_values({'deployed': 'foo'}, filename)
+    utils.record_deployed_values({'dev': {'deployed': 'foo'}}, filename)
     with open(filename, 'r') as f:
-        assert json.load(f) == {'deployed': 'foo'}
+        assert json.load(f) == {'dev': {'deployed': 'foo'}}
+
+
+def test_can_merge_recorded_values(tmpdir):
+    filename = str(tmpdir.join('deployed.json'))
+    first = {'dev': {'deployed': 'values'}}
+    second = {'prod': {'deployed': 'values'}}
+    utils.record_deployed_values(first, filename)
+    utils.record_deployed_values(second, filename)
+    combined = first.copy()
+    combined.update(second)
+    with open(filename, 'r') as f:
+        data = json.load(f)
+    assert data == combined

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -1,4 +1,5 @@
 import zipfile
+import json
 
 from chalice import utils
 
@@ -35,3 +36,10 @@ def test_can_zip_recursive_contents(tmpdir):
             'subdir/subsubdir/leaf.txt',
         ]
         assert f.read('subdir/subsubdir/leaf.txt') == 'leaf.txt'
+
+
+def test_can_write_recorded_values(tmpdir):
+    filename = str(tmpdir.join('deployed.json'))
+    utils.record_deployed_values({'deployed': 'foo'}, filename)
+    with open(filename, 'r') as f:
+        assert json.load(f) == {'deployed': 'foo'}

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,4 +1,4 @@
-from chalice.config import Config
+from chalice.config import Config, DeployedResources
 
 
 def test_config_create_method():
@@ -53,3 +53,22 @@ def test_user_params_is_optional():
     c = Config(config_from_disk={'stage': 'config_from_disk'},
                default_params={'stage': 'default_params'})
     assert c.stage == 'config_from_disk'
+
+
+def test_can_create_deployed_resource_from_dict():
+    d = DeployedResources.from_dict({
+        'backend': 'api',
+        'api_handler_arn': 'arn',
+        'api_handler_name': 'name',
+        'rest_api_id': 'id',
+        'api_gateway_stage': 'stage',
+        'region': 'region',
+        'chalice_version': '1.0.0',
+    })
+    assert d.backend == 'api'
+    assert d.api_handler_arn == 'arn'
+    assert d.api_handler_name == 'name'
+    assert d.rest_api_id == 'id'
+    assert d.api_gateway_stage == 'stage'
+    assert d.region == 'region'
+    assert d.chalice_version == '1.0.0'


### PR DESCRIPTION
This introduces a change to how stages work in chalice.
Previously a "stage" in chalice corresponded to an API gateway
stage.  While this could theoretically work for lambda functions
as well (via aliasing and function versions) it would not necessarily
scale with other AWS resources.  Now, chalice "stages" are
entirely new sets of resources.  For example, if I run:

```
$ chalice deploy dev  # Note 'dev' can be omitted, it's the default
$ chalice deploy prod
```

I will have two completely separate sets of API gateway rest APIs,
Lambda functions, and IAM roles.
To help track this, a ".chalice/deployed.json" is written on deploys
that contains the deployed values per-stage.

There's still some additional work remaining, primarily against
upgrading from old versions to this new version.  We should be warning
or erroring out in that scenario, but that will be addressed as a
separate commit.

Additionally, the "chalice url/logs" command can be updated to use
the ".chalice/deployed.json" file as well, but that will be added as
a separate commit.