### PR TITLE
Remove references to lambda_arn

### DIFF
--- a/chalice/config.py
+++ b/chalice/config.py
@@ -133,11 +133,6 @@ class Config(object):
                 return cfg_dict[name]
 
     @property
-    def lambda_arn(self):
-        # type: () -> str
-        return self._chain_lookup('lambda_arn')
-
-    @property
     def config_file_version(self):
         # type: () -> str
         return self._config_from_disk.get('version', '1.0')

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5,7 +5,6 @@ def test_config_create_method():
     c = Config.create(app_name='foo')
     assert c.app_name == 'foo'
     # Otherwise attributes default to None meaning 'not set'.
-    assert c.lambda_arn is None
     assert c.profile is None
     assert c.api_gateway_stage is None
 
@@ -35,12 +34,10 @@ def test_manage_iam_role_explicitly_set():
 def test_can_chain_lookup():
     user_provided_params = {
         'api_gateway_stage': 'user_provided_params',
-        'lambda_arn': 'user_provided_params',
     }
 
     config_from_disk = {
         'api_gateway_stage': 'config_from_disk',
-        'lambda_arn': 'config_from_disk',
         'app_name': 'config_from_disk',
     }
 
@@ -52,7 +49,6 @@ def test_can_chain_lookup():
 
     c = Config('dev', user_provided_params, config_from_disk, default_params)
     assert c.api_gateway_stage == 'user_provided_params'
-    assert c.lambda_arn == 'user_provided_params'
     assert c.app_name == 'config_from_disk'
     assert c.project_dir == 'default_params'
 


### PR DESCRIPTION
The `config.lambda_arn` was previously used to lookup
the value of a previously deployed lambda function.
This is now handled by .chalice/deployed.json.

To accomplish this, I had to update the signature of the
API Gateway deployer to pass in the deployed lambda_arn, which
is needed for the swagger document.  I was considering using
the "existing resources" object, but it's not clear if allowing
a partially hydrated deployed resources object is a good idea or not.
For now I'm just explicitly passing in the data I need from
previous deployement steps (just the lambda_arn).