### PR TITLE
Add support for environment_variables config option

### DIFF
--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -84,10 +84,16 @@ class TypedAWSClient(object):
         lambda_client = self._client('lambda')
         return_value = lambda_client.update_function_code(
             FunctionName=function_name, ZipFile=zip_contents)
-        if environment_variables is not None:
-            lambda_client.update_function_configuration(
-                FunctionName=function_name,
-                Environment={"Variables": environment_variables})
+        if environment_variables is None:
+            environment_variables = {}
+        # We need to handle the case where the user removes
+        # all env vars from their config.json file.  We'll
+        # just call update_function_configuration every time.
+        # We're going to need this moving forward anyways,
+        # more config options besides env vars will be added.
+        lambda_client.update_function_configuration(
+            FunctionName=function_name,
+            Environment={"Variables": environment_variables})
         return return_value
 
     def get_role_arn_for_name(self, name):

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -286,12 +286,12 @@ def package(ctx, single_file, stage, out):
     if single_file:
         dirname = tempfile.mkdtemp()
         try:
-            packager.package_app(dirname)
+            packager.package_app(config, dirname)
             create_zip_file(source_dir=dirname, outfile=out)
         finally:
             shutil.rmtree(dirname)
     else:
-        packager.package_app(out)
+        packager.package_app(config, out)
 
 
 def run_local_server(app_obj, port):

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -243,10 +243,11 @@ class LambdaDeployer(object):
         role_arn = self._get_or_create_lambda_role_arn(config, function_name)
         zip_filename = self._packager.create_deployment_package(
             config.project_dir)
-        with open(zip_filename, 'rb') as f:
-            zip_contents = f.read()
+        zip_contents = self._osutils.get_file_contents(
+            zip_filename, binary=True)
         return self._aws_client.create_function(
-            function_name, role_arn, zip_contents)
+            function_name, role_arn, zip_contents,
+            config.environment_variables)
 
     def _update_lambda_function(self, config, lambda_name):
         # type: (Config, str) -> None
@@ -264,7 +265,8 @@ class LambdaDeployer(object):
         zip_contents = self._osutils.get_file_contents(
             deployment_package_filename, binary=True)
         print "Sending changes to lambda."
-        self._aws_client.update_function_code(lambda_name, zip_contents)
+        self._aws_client.update_function(lambda_name, zip_contents,
+                                         config.environment_variables)
 
     def _write_config_to_disk(self, config):
         # type: (Config) -> None

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -25,8 +25,11 @@ def test_deploy_rest_api(stubbed_session):
 
 
 def test_update_function_code_only(stubbed_session):
-    stubbed_session.stub('lambda').update_function_code(
+    lambda_client = stubbed_session.stub('lambda')
+    lambda_client.update_function_code(
         FunctionName='name', ZipFile=b'foo').returns({})
+    lambda_client.update_function_configuration(
+        FunctionName='name', Environment={'Variables': {}}).returns({})
     stubbed_session.activate_stubs()
     awsclient = TypedAWSClient(stubbed_session)
     awsclient.update_function('name', b'foo')

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -24,10 +24,12 @@ def test_deploy_rest_api(stubbed_session):
     stubbed_session.verify_stubs()
 
 
-def test_update_function_code_only(stubbed_session):
+def test_always_update_function_code(stubbed_session):
     lambda_client = stubbed_session.stub('lambda')
     lambda_client.update_function_code(
         FunctionName='name', ZipFile=b'foo').returns({})
+    # Even if there's only a code change, we'll always call
+    # update_function_configuration.
     lambda_client.update_function_configuration(
         FunctionName='name', Environment={'Variables': {}}).returns({})
     stubbed_session.activate_stubs()

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -24,12 +24,26 @@ def test_deploy_rest_api(stubbed_session):
     stubbed_session.verify_stubs()
 
 
-def test_update_function_code(stubbed_session):
+def test_update_function_code_only(stubbed_session):
     stubbed_session.stub('lambda').update_function_code(
         FunctionName='name', ZipFile=b'foo').returns({})
     stubbed_session.activate_stubs()
     awsclient = TypedAWSClient(stubbed_session)
-    awsclient.update_function_code('name', b'foo')
+    awsclient.update_function('name', b'foo')
+    stubbed_session.verify_stubs()
+
+
+def test_update_function_code_and_deploy(stubbed_session):
+    lambda_client = stubbed_session.stub('lambda')
+    lambda_client.update_function_code(
+        FunctionName='name', ZipFile=b'foo').returns({})
+    lambda_client.update_function_configuration(
+        FunctionName='name',
+        Environment={'Variables': {"FOO": "BAR"}}).returns({})
+    stubbed_session.activate_stubs()
+    awsclient = TypedAWSClient(stubbed_session)
+    awsclient.update_function(
+        'name', b'foo', {"FOO": "BAR"})
     stubbed_session.verify_stubs()
 
 
@@ -215,11 +229,12 @@ class TestCreateLambdaFunction(object):
             Handler='app.app',
             Role='myarn',
             Timeout=60,
+            Environment={'Variables': {'FOO': 'BAR'}},
         ).returns({'FunctionArn': 'arn:12345:name'})
         stubbed_session.activate_stubs()
         awsclient = TypedAWSClient(stubbed_session)
         assert awsclient.create_function(
-            'name', 'myarn', b'foo') == 'arn:12345:name'
+            'name', 'myarn', b'foo', {'FOO': 'BAR'}) == 'arn:12345:name'
         stubbed_session.verify_stubs()
 
     def test_create_function_is_retried_and_succeeds(self, stubbed_session):

--- a/tests/functional/test_package.py
+++ b/tests/functional/test_package.py
@@ -30,7 +30,7 @@ def test_can_create_app_packager_with_no_autogen(tmpdir):
     config = Config.create(project_dir=str(appdir),
                            chalice_app=sample_app())
     p = package.create_app_packager(config)
-    p.package_app(str(outdir))
+    p.package_app(config, str(outdir))
     # We're not concerned with the contents of the files
     # (those are tested in the unit tests), we just want to make
     # sure they're written to disk and look (mostly) right.
@@ -45,7 +45,7 @@ def test_will_create_outdir_if_needed(tmpdir):
     config = Config.create(project_dir=str(appdir),
                            chalice_app=sample_app())
     p = package.create_app_packager(config)
-    p.package_app(outdir)
+    p.package_app(config, str(outdir))
     contents = os.listdir(str(outdir))
     assert 'deployment.zip' in contents
     assert 'sam.json' in contents

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -103,3 +103,46 @@ def test_can_create_deployed_resource_from_dict():
     assert d.api_gateway_stage == 'stage'
     assert d.region == 'region'
     assert d.chalice_version == '1.0.0'
+
+
+def test_environment_from_top_level():
+    config_from_disk = {'environment_variables': {"foo": "bar"}}
+    c = Config('dev', config_from_disk=config_from_disk)
+    assert c.environment_variables == config_from_disk['environment_variables']
+
+
+def test_environment_from_stage_leve():
+    config_from_disk = {
+        'stages': {
+            'prod': {
+                'environment_variables': {"foo": "bar"}
+            }
+        }
+    }
+    c = Config('prod', config_from_disk=config_from_disk)
+    assert c.environment_variables == \
+            config_from_disk['stages']['prod']['environment_variables']
+
+
+def test_env_vars_chain_merge():
+    config_from_disk = {
+        'environment_variables': {
+            'top_level': 'foo',
+            'shared_key': 'from-top',
+        },
+        'stages': {
+            'prod': {
+                'environment_variables': {
+                    'stage_var': 'bar',
+                    'shared_key': 'from-stage',
+                }
+            }
+        }
+    }
+    c = Config('prod', config_from_disk=config_from_disk)
+    resolved = c.environment_variables
+    assert resolved == {
+        'top_level': 'foo',
+        'stage_var': 'bar',
+        'shared_key': 'from-stage',
+    }


### PR DESCRIPTION
These changes include:

This builds on the initial work from @emellis (#243) and adds
support for the environment variables config option.

* Updating the config object with an environment_variables property
* Adding the concept of "chain merge" to config.  This allows
a dict to be updated (merged) instead of returning on the first value
found.
* Update API based deployer to inject env vars when needed.  This is
needed for both create_function and update_function calls.
* Changed update_function_code to just update_function which will
optionally update function config if required
* Update packager to add environment variables to SAM template.

NOTE: This doesn't merge cleanly on the package branch, and I based
it off the latest PR (#272).  The only commit you need to review here
is the latest commit: https://github.com/jamesls/chalice/commit/507dd116f36c038dabc1b9287c60d99fe3339955