### PR TITLE
FIX: No JSON object could be decoded (line 123) [chalice==0.7.0]

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -119,9 +119,9 @@ class Request(object):
     @property
     def json_body(self):
         if self.headers.get('content-type', '').startswith('application/json'):
-            if self._json_body is None:
-                self._json_body = json.loads(self.raw_body)
-            return self._json_body
+            if self._json_body is None and self.raw_body:
+                    self._json_body = json.loads(self.raw_body)
+            return self._json_body or {}
 
     def to_dict(self):
         copied = self.__dict__.copy()


### PR DESCRIPTION
I was getting Traceback (most recent call last):
  File "/var/task/chalice/app.py", line 316, in _get_view_function_response
    response = self._invoke_view_function(view_function, function_args)
  File "/var/task/chalice/app.py", line 344, in _invoke_view_function
    response = view_function(*function_args)
  File "/var/task/app.py", line 138, in getData
    obj = app.current_request.json_body
  File "/var/task/chalice/app.py", line 123, in json_body
    self._json_body = json.loads(self.raw_body)
  File "/usr/lib64/python2.7/json/__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "/usr/lib64/python2.7/json/decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib64/python2.7/json/decoder.py", line 382, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded

So I guessed it's better not to json.loads() a NoneType.