### PR TITLE
GZIP Enabled

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -132,12 +132,13 @@ class Request(object):
 
 
 class Response(object):
-    def __init__(self, body, headers=None, status_code=200):
+    def __init__(self, body, headers=None, status_code=200, is_base_64_encoded=False):
         self.body = body
         if headers is None:
             headers = {}
         self.headers = headers
         self.status_code = status_code
+        self.is_base_64_encoded = is_base_64_encoded
 
     def to_dict(self):
         body = self.body
@@ -147,6 +148,7 @@ class Response(object):
             'headers': self.headers,
             'statusCode': self.status_code,
             'body': body,
+            'is_base_64_encoded': self.is_base_64_encoded,
         }
 
 

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -148,7 +148,7 @@ class Response(object):
             'headers': self.headers,
             'statusCode': self.status_code,
             'body': body,
-            'is_base_64_encoded': self.is_base_64_encoded,
+            'isBase64Encoded': self.is_base_64_encoded,
         }
 
 


### PR DESCRIPTION
For anyone who wants to use Gzip compression on a lambda to save 80% of data transfer use Gzip with StreamIO and NOT Zlib.
Also, you'll have to add the mime types you want to the API gateway "Binary Support" (it's a vertical tab under the "Stages" of your API, see http://imgur.com/a/d38La )  

Also, after a couple of hours with AWS support on the phone, we found out that CloudFront expects an "'isBase64Encoded': True" parameter from the Lambda (as a sibling of body, headers and the rest... yeah... -_-" )

So, as a really cool option you can add this...


Meanwhile, I work it around by extending your Response class and returning it where I need compression:


	from chalice import Response
	
	class CompressedResponse(Response, object):
		def __init__(self, body, headers=None, status_code=200, isBase64Encoded=True):
			super(CompressedResponse, self).__init__(body, headers, status_code)
			self.isBase64Encoded = isBase64Encoded
	
		def to_dict(self):
			body = self.body
			if not isinstance(body, str):
				body = json.dumps(body, default=handle_decimals)
			return {
				'headers': self.headers,
				'statusCode': self.status_code,
				'body': body,
				'isBase64Encoded': self.isBase64Encoded,
			}


NOTE: As you can see, I use is_base_64_encoded=True by default. First, because it's actually a class for compression :) and second, because since the binary support is enabled I prefer to save 80% of data transfer... 
The original object weights around 200K, after compression+base64 ( base64 is needed by CloudFront and a Lambda can't output binary data ) it weights 37K ~ 40K --> less than 1 fifth.