### PR TITLE
Install requirements file into codebuild template

### DIFF
--- a/chalice/pipeline.py
+++ b/chalice/pipeline.py
@@ -118,6 +118,7 @@ class CodeBuild(BaseResource):
                         "      - sudo pip install --upgrade awscli\n"
                         "      - aws --version\n"
                         "      - sudo pip install chalice\n"
+                        "      - sudo pip install -r requirements.txt\n"
                         "      - chalice package /tmp/packaged\n"
                         "      - aws cloudformation package"
                         " --template-file /tmp/packaged/sam.json"

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -67,3 +67,11 @@ def test_codepipeline_resource(pipeline_gen):
     resources['ArtifactBucketStore']['Type'] == 'AWS::S3::Bucket'
     resources['CodePipelineRole']['Type'] == 'AWS::IAM::Role'
     resources['CFNDeployRole']['Type'] == 'AWS::IAM::Role'
+
+
+def test_install_requirements_in_buildspec(pipeline_gen):
+    template = {}
+    pipeline.CodeBuild().add_to_template(template)
+    build = template['Resources']['AppPackageBuild']
+    build_spec = build['Properties']['Source']['BuildSpec']
+    assert 'pip install -r requirements.txt' in build_spec


### PR DESCRIPTION
This would otherwise crash when we tried to import `app` in the codebuild build.