### PR TITLE
Always overwrite API gateway API on updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 CHANGELOG
 =========
 
+Next Release (TBD)
+==================
+
+* Alway overwrite existing API Gateway Rest API on updates
+  (`#305 <https://github.com/awslabs/chalice/issues/305>`__)
+
+
 0.8.0
 =====
 

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -187,6 +187,7 @@ class TypedAWSClient(object):
         client = self._client('apigateway')
         client.put_rest_api(
             restApiId=rest_api_id,
+            mode='overwrite',
             body=json.dumps(swagger_document, indent=2))
 
     def deploy_rest_api(self, rest_api_id, api_gateway_stage):

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -464,6 +464,7 @@ class TestAddPermissionsForAPIGateway(object):
         swagger_doc = {'swagger': 'doc'}
         apig.put_rest_api(
             restApiId='rest_api_id',
+            mode='overwrite',
             body=json.dumps(swagger_doc, indent=2)).returns({})
 
         stubbed_session.activate_stubs()


### PR DESCRIPTION
The default if not specified is `merge`, which is not what we want.

Working on a follow up PR to get integ tests added for this.

Fixes #305