### PR TITLE
Add support for a more granular CORSConfig object.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,8 @@ Next Release (TBD)
 
 * Alway overwrite existing API Gateway Rest API on updates
   (`#305 <https://github.com/awslabs/chalice/issues/305>`__)
-
+* Added more granular support for CORS
+  (`#311 <https://github.com/awslabs/chalice/pull/311>`__)
 
 0.8.0
 =====

--- a/README.rst
+++ b/README.rst
@@ -730,15 +730,54 @@ The preflight request will return a response that includes:
 * ``Access-Control-Allow-Headers: Content-Type,X-Amz-Date,Authorization,
   X-Api-Key,X-Amz-Security-Token``.
 
+If more fine grained control of the CORS headers is desired, set the ``cors``
+parameter to an instance of ``CORSConfig`` instead of ``True``. The
+``CORSConfig`` object can be imported from from the ``chalice`` package it's
+constructor takes the following keyword arguments that map to CORS headers:
+
+================= ==== ================================
+Argument          Type Header
+================= ==== ================================
+allow_origin      str  Access-Control-Allow-Origin
+allow_headers     list Access-Control-Allow-Headers
+expose_headers    list Access-Control-Expose-Headers
+max_age           int  Access-Control-Max-Age
+allow_credentials bool Access-Control-Allow-Credentials
+================= ==== ================================
+
+Code sample defining more CORS headers:
+
+.. code-block:: python
+
+    from chalice import CORSConfig
+    cors_config = CORSConfig(
+        allow_origin='https://foo.example.com',
+        allow_headers=['X-Special-Header'],
+        max_age=600,
+        expose_headers=['X-Special-Header'],
+	allow_credentials=True
+    )
+    @app.route('/custom_cors', methods=['GET'], cors=cors_config)
+    def supports_custom_cors():
+        return {'cors': True}
+
+
 There's a couple of things to keep in mind when enabling cors for a view:
 
 * An ``OPTIONS`` method for preflighting is always injected.  Ensure that
   you don't have ``OPTIONS`` in the ``methods=[...]`` list of your
   view function.
+* Even though the ``Access-Control-Allow-Origin`` header can be set to a
+  string that is a space separated list of origins, this behavior does not
+  work on all clients that implement CORS. You should only supply a single
+  origin to the ``CORSConfig`` object. If you need to supply multiple origins
+  you will need to define a custom handler for it that accepts ``OPTIONS``
+  requests and matches the ``Origin`` header against a whitelist of origins.
+  If the match is succssful then return just their ``Origin`` back to them
+  in the ``Access-Control-Allow-Origin`` header.
 * Every view function must explicitly enable CORS support.
-* There's no support for customizing the CORS configuration.
 
-The last two points will change in the future.  See
+The last point will change in the future.  See
 `this issue
 <https://github.com/awslabs/chalice/issues/70#issuecomment-248787037>`_
 for more information.

--- a/chalice/__init__.py
+++ b/chalice/__init__.py
@@ -1,7 +1,7 @@
 from chalice.app import Chalice
 from chalice.app import (
     ChaliceViewError, BadRequestError, UnauthorizedError, ForbiddenError,
-    NotFoundError, ConflictError, TooManyRequestsError, Response
+    NotFoundError, ConflictError, TooManyRequestsError, Response, CORSConfig
 )
 
 __version__ = '0.8.0'

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -100,6 +100,54 @@ class CaseInsensitiveMapping(Mapping):
         return 'CaseInsensitiveMapping(%s)' % repr(self._dict)
 
 
+class CORSConfig(object):
+    """A cors configuration to attach to a route."""
+
+    _REQUIRED_HEADERS = ['Content-Type', 'X-Amz-Date', 'Authorization',
+                         'X-Api-Key', 'X-Amz-Security-Token']
+
+    def __init__(self, allow_origin='*', allow_headers=None,
+                 expose_headers=None, max_age=None, allow_credentials=None):
+        self.allow_origin = allow_origin
+
+        if allow_headers is None:
+            allow_headers = list(self._REQUIRED_HEADERS)
+        else:
+            allow_headers.extend(self._REQUIRED_HEADERS)
+        self._allow_headers = allow_headers
+
+        if expose_headers is None:
+            expose_headers = []
+        self._expose_headers = expose_headers
+
+        self._max_age = max_age
+        self._allow_credentials = allow_credentials
+
+    @property
+    def allow_headers(self):
+        return ','.join(self._allow_headers)
+
+    def get_access_control_headers(self):
+        headers = {
+            'Access-Control-Allow-Origin': self.allow_origin,
+            'Access-Control-Allow-Headers': ','.join(self._allow_headers),
+        }
+        if self._expose_headers:
+            headers.update({
+                'Access-Control-Expose-Headers': ','.join(self._expose_headers)
+            })
+        if self._max_age is not None:
+            headers.update({
+                'Access-Control-Max-Age': str(self._max_age)
+            })
+        if self._allow_credentials is not None:
+            headers.update({
+                'Access-Control-Allow-Credentials': self._allow_credentials
+            })
+
+        return headers
+
+
 class Request(object):
     """The current request from API gateway."""
 
@@ -167,6 +215,10 @@ class RouteEntry(object):
         #: e.g, '/foo/{bar}/{baz}/qux -> ['bar', 'baz']
         self.view_args = self._parse_view_args()
         self.content_types = content_types
+        if cors is True:
+            cors = CORSConfig()
+        elif cors is False:
+            cors = None
         self.cors = cors
 
     def _parse_view_args(self):
@@ -309,7 +361,7 @@ class Chalice(object):
         response = self._get_view_function_response(view_function,
                                                     function_args)
         if self._cors_enabled_for_route(route_entry):
-            self._add_cors_headers(response)
+            self._add_cors_headers(response, route_entry.cors)
         return response.to_dict()
 
     def _get_view_function_response(self, view_function, function_args):
@@ -354,7 +406,7 @@ class Chalice(object):
                                        (header, value))
 
     def _cors_enabled_for_route(self, route_entry):
-        return route_entry.cors
+        return route_entry.cors is not None
 
-    def _add_cors_headers(self, response):
-        response.headers['Access-Control-Allow-Origin'] = '*'
+    def _add_cors_headers(self, response, cors):
+        response.headers.update(cors.get_access_control_headers())

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -17,6 +17,8 @@ ALL_ERRORS = ... # type: List[ChaliceViewError]
 class CORSConfig:
     allow_origin = ... # type: str
     allow_headers = ... # type: str
+    get_access_control_headers = ... # type: Callable[..., Dict[str, str]]
+
 
 class Request:
     query_params = ... # type: Dict[str, str]

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -1,4 +1,4 @@
-from typing import Dict, List, Any, Callable
+from typing import Dict, List, Any, Callable, Union
 
 class ChaliceError(Exception): ...
 class ChaliceViewError(ChaliceError):
@@ -13,6 +13,10 @@ class TooManyRequestsError(ChaliceViewError): ...
 
 
 ALL_ERRORS = ... # type: List[ChaliceViewError]
+
+class CORSConfig:
+    allow_origin = ... # type: str
+    allow_headers = ... # type: str
 
 class Request:
     query_params = ... # type: Dict[str, str]
@@ -60,14 +64,14 @@ class RouteEntry(object):
     api_key_required = ... # type: bool
     content_types = ... # type: List[str]
     view_args = ... # type: List[str]
-    cors = ... # type: bool
+    cors = ... # type: CORSConfig
 
     def __init__(self, view_function: Callable[..., Any],
                  view_name: str, path: str, methods: List[str],
                  authorizer_name: str=None,
                  api_key_required: bool=None,
                  content_types: List[str]=None,
-                 cors: bool=False) -> None: ...
+                 cors: Union[bool, CORSConfig]=False) -> None: ...
 
     def _parse_view_args(self) -> List[str]: ...
 

--- a/chalice/deploy/swagger.py
+++ b/chalice/deploy/swagger.py
@@ -144,14 +144,15 @@ class SwaggerGenerator(object):
         cors = view.cors
         methods = view.methods + ['OPTIONS']
         allowed_methods = ','.join(methods)
+
         response_params = {
-            "method.response.header.Access-Control-Allow-Methods": (
-                "'%s'" % allowed_methods),
-            "method.response.header.Access-Control-Allow-Origin": (
-                "'%s'" % cors.allow_origin),
-            "method.response.header.Access-Control-Allow-Headers": (
-                "'%s'" % cors.allow_headers)
+            'Access-Control-Allow-Methods': '%s' % allowed_methods
         }
+        response_params.update(cors.get_access_control_headers())
+
+        headers = {k: {'type': 'string'} for k, _ in response_params.items()}
+        response_params = {'method.response.header.%s' % k: "'%s'" % v for k, v
+                           in response_params.items()}
 
         options_request = {
             "consumes": ["application/json"],
@@ -160,11 +161,7 @@ class SwaggerGenerator(object):
                 "200": {
                     "description": "200 response",
                     "schema": {"$ref": "#/definitions/Empty"},
-                    "headers": {
-                        "Access-Control-Allow-Origin": {"type": "string"},
-                        "Access-Control-Allow-Methods": {"type": "string"},
-                        "Access-Control-Allow-Headers": {"type": "string"},
-                    }
+                    "headers": headers
                 }
             },
             "x-amazon-apigateway-integration": {

--- a/chalice/deploy/swagger.py
+++ b/chalice/deploy/swagger.py
@@ -46,7 +46,7 @@ class SwaggerGenerator(object):
                     self._add_to_security_definition(
                         current['security'], api, app.authorizers)
                 swagger_for_path[http_method.lower()] = current
-            if view.cors:
+            if view.cors is not None:
                 self._add_preflight_request(view, swagger_for_path)
 
     def _add_to_security_definition(self, security, api_config, authorizers):
@@ -141,15 +141,16 @@ class SwaggerGenerator(object):
 
     def _add_preflight_request(self, view, swagger_for_path):
         # type: (RouteEntry, Dict[str, Any]) -> None
+        cors = view.cors
         methods = view.methods + ['OPTIONS']
         allowed_methods = ','.join(methods)
         response_params = {
             "method.response.header.Access-Control-Allow-Methods": (
                 "'%s'" % allowed_methods),
+            "method.response.header.Access-Control-Allow-Origin": (
+                "'%s'" % cors.allow_origin),
             "method.response.header.Access-Control-Allow-Headers": (
-                "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,"
-                "X-Amz-Security-Token'"),
-            "method.response.header.Access-Control-Allow-Origin": "'*'"
+                "'%s'" % cors.allow_headers)
         }
 
         options_request = {

--- a/chalice/local.py
+++ b/chalice/local.py
@@ -8,9 +8,9 @@ from collections import namedtuple
 from six.moves.BaseHTTPServer import HTTPServer
 from six.moves.BaseHTTPServer import BaseHTTPRequestHandler
 
-from chalice.app import Chalice  # noqa
+from chalice.app import Chalice, CORSConfig  # noqa
+from typing import List, Any, Dict, Tuple, Callable # noqa
 from chalice.compat import urlparse, parse_qs
-from typing import List, Any, Dict, Tuple, Callable  # noqa
 
 
 MatchResult = namedtuple('MatchResult', ['route', 'captured', 'query_params'])
@@ -156,7 +156,7 @@ class ChaliceRequestHandler(BaseHTTPRequestHandler):
             self._send_autogen_options_response()
 
     def _cors_enabled_for_route(self, lambda_event):
-        # type: (EventType) -> bool
+        # type: (EventType) -> CORSConfig
         route_key = lambda_event['requestContext']['resourcePath']
         route_entry = self.app_object.routes[route_key]
         return route_entry.cors

--- a/chalice/local.py
+++ b/chalice/local.py
@@ -9,7 +9,7 @@ from six.moves.BaseHTTPServer import HTTPServer
 from six.moves.BaseHTTPServer import BaseHTTPRequestHandler
 
 from chalice.app import Chalice, CORSConfig  # noqa
-from typing import List, Any, Dict, Tuple, Callable # noqa
+from typing import List, Any, Dict, Tuple, Callable  # noqa
 from chalice.compat import urlparse, parse_qs
 
 

--- a/tests/integration/test_features.py
+++ b/tests/integration/test_features.py
@@ -188,7 +188,8 @@ def test_can_support_cors(smoke_test_app):
     headers = response.headers
     assert headers['Access-Control-Allow-Origin'] == '*'
     assert headers['Access-Control-Allow-Headers'] == (
-        'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token')
+        'Authorization,Content-Type,X-Amz-Date,X-Amz-Security-Token,'
+        'X-Api-Key')
     assert headers['Access-Control-Allow-Methods'] == 'GET,POST,PUT,OPTIONS'
 
 
@@ -203,11 +204,15 @@ def test_can_support_custom_cors(smoke_test_app):
     response = requests.options(smoke_test_app.url + '/custom_cors')
     response.raise_for_status()
     headers = response.headers
+    print(headers)
     assert headers['Access-Control-Allow-Origin'] == expected_allow_origin
     assert headers['Access-Control-Allow-Headers'] == (
-        'X-Special-Header,Content-Type,X-Amz-Date,Authorization,X-Api-Key,'
-        'X-Amz-Security-Token')
+        'Authorization,Content-Type,X-Amz-Date,X-Amz-Security-Token,'
+        'X-Api-Key,X-Special-Header')
     assert headers['Access-Control-Allow-Methods'] == 'GET,POST,PUT,OPTIONS'
+    assert headers['Access-Control-Max-Age'] == '600'
+    assert headers['Access-Control-Expose-Headers'] == 'X-Special-Header'
+    assert headers['Access-Control-Allow-Credentials'] == 'true'
 
 
 def test_to_dict_is_also_json_serializable(smoke_test_app):

--- a/tests/integration/test_features.py
+++ b/tests/integration/test_features.py
@@ -192,6 +192,24 @@ def test_can_support_cors(smoke_test_app):
     assert headers['Access-Control-Allow-Methods'] == 'GET,POST,PUT,OPTIONS'
 
 
+def test_can_support_custom_cors(smoke_test_app):
+    response = requests.get(smoke_test_app.url + '/custom_cors')
+    response.raise_for_status()
+    expected_allow_origin = 'https://foo.example.com'
+    assert response.headers[
+        'Access-Control-Allow-Origin'] == expected_allow_origin
+
+    # Should also have injected an OPTIONs request.
+    response = requests.options(smoke_test_app.url + '/custom_cors')
+    response.raise_for_status()
+    headers = response.headers
+    assert headers['Access-Control-Allow-Origin'] == expected_allow_origin
+    assert headers['Access-Control-Allow-Headers'] == (
+        'X-Special-Header,Content-Type,X-Amz-Date,Authorization,X-Api-Key,'
+        'X-Amz-Security-Token')
+    assert headers['Access-Control-Allow-Methods'] == 'GET,POST,PUT,OPTIONS'
+
+
 def test_to_dict_is_also_json_serializable(smoke_test_app):
     assert 'headers' in smoke_test_app.get_json('/todict')
 

--- a/tests/integration/testapp/app.py
+++ b/tests/integration/testapp/app.py
@@ -1,6 +1,10 @@
 from chalice import Chalice, BadRequestError, NotFoundError, Response,\
     CORSConfig
-from chalice.compat import parse_qs
+
+try:
+    from urllib.parse import parse_qs
+except:
+    from urlparse import parse_qs
 
 # This is a test app that is used by integration tests.
 # This app exercises all the major features of chalice
@@ -81,7 +85,7 @@ def supports_cors():
     allow_headers=['X-Special-Header'],
     max_age=600,
     expose_headers=['X-Special-Header'],
-    allow_credentials=False))
+    allow_credentials=True))
 def supports_custom_cors():
     return {'cors': True}
 

--- a/tests/integration/testapp/app.py
+++ b/tests/integration/testapp/app.py
@@ -1,4 +1,5 @@
-from chalice import Chalice, BadRequestError, NotFoundError, Response
+from chalice import Chalice, BadRequestError, NotFoundError, Response,\
+    CORSConfig
 from chalice.compat import parse_qs
 
 # This is a test app that is used by integration tests.
@@ -72,6 +73,16 @@ def form_encoded():
 def supports_cors():
     # It doesn't really matter what we return here because
     # we'll be checking the response headers to verify CORS support.
+    return {'cors': True}
+
+
+@app.route('/custom_cors', methods=['GET', 'POST', 'PUT'], cors=CORSConfig(
+    allow_origin='https://foo.example.com',
+    allow_headers=['X-Special-Header'],
+    max_age=600,
+    expose_headers=['X-Special-Header'],
+    allow_credentials=False))
+def supports_custom_cors():
     return {'cors': True}
 
 

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -74,7 +74,10 @@ def test_can_add_multiple_http_methods(sample_app, swagger_gen):
 def test_can_add_preflight_cors(sample_app, swagger_gen):
     @sample_app.route('/cors', methods=['GET', 'POST'], cors=CORSConfig(
         allow_origin='http://foo.com',
-        allow_headers=['X-Special-Header']))
+        allow_headers=['X-ZZ-Top', 'X-Special-Header'],
+        expose_headers=['X-Exposed', 'X-Special'],
+        max_age=600,
+        allow_credentials=True))
     def cors_request():
         pass
 
@@ -88,10 +91,17 @@ def test_can_add_preflight_cors(sample_app, swagger_gen):
         'method.response.header.Access-Control-Allow-Methods': (
             "'GET,POST,OPTIONS'"),
         'method.response.header.Access-Control-Allow-Headers': (
-            "'X-Special-Header,Content-Type,X-Amz-Date,Authorization,"
-            "X-Api-Key,X-Amz-Security-Token'"),
+            "'Authorization,Content-Type,X-Amz-Date,X-Amz-Security-Token,"
+            "X-Api-Key,X-Special-Header,X-ZZ-Top'"),
         'method.response.header.Access-Control-Allow-Origin': (
             "'http://foo.com'"),
+        'method.response.header.Access-Control-Expose-Headers': (
+            "'X-Exposed,X-Special'"),
+        'method.response.header.Access-Control-Max-Age': (
+            "'600'"),
+        'method.response.header.Access-Control-Allow-Credentials': (
+            "'true'"),
+
     }
     assert options == {
         'consumes': ['application/json'],
@@ -106,6 +116,9 @@ def test_can_add_preflight_cors(sample_app, swagger_gen):
                     'Access-Control-Allow-Origin': {'type': 'string'},
                     'Access-Control-Allow-Methods': {'type': 'string'},
                     'Access-Control-Allow-Headers': {'type': 'string'},
+                    'Access-Control-Expose-Headers': {'type': 'string'},
+                    'Access-Control-Max-Age': {'type': 'string'},
+                    'Access-Control-Allow-Credentials': {'type': 'string'},
                 }
             }
         },
@@ -140,8 +153,8 @@ def test_can_add_preflight_custom_cors(sample_app, swagger_gen):
         'method.response.header.Access-Control-Allow-Methods': (
             "'GET,POST,OPTIONS'"),
         'method.response.header.Access-Control-Allow-Headers': (
-            "'Content-Type,X-Amz-Date,Authorization,"
-            "X-Api-Key,X-Amz-Security-Token'"),
+            "'Authorization,Content-Type,X-Amz-Date,X-Amz-Security-Token,"
+            "X-Api-Key'"),
         'method.response.header.Access-Control-Allow-Origin': "'*'",
     }
     assert options == {

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -166,6 +166,7 @@ def test_can_support_patch_method(handler):
     handler.do_PATCH()
     assert _get_body_from_response_stream(handler) == {'patch': True}
 
+
 def test_can_support_decimals(handler):
     set_current_request(handler, method='GET', path='/decimals')
     handler.do_PATCH()

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -1,4 +1,4 @@
-from chalice import local, BadRequestError
+from chalice import local, BadRequestError, CORSConfig
 import json
 import decimal
 import pytest
@@ -40,6 +40,16 @@ def sample_app():
 
     @demo.route('/cors', methods=['GET', 'PUT'], cors=True)
     def cors():
+        return {'cors': True}
+
+    @demo.route('/custom_cors', methods=['GET', 'PUT'], cors=CORSConfig(
+        allow_origin='https://foo.bar',
+        allow_headers=['Header-A', 'Header-B'],
+        expose_headers=['Header-A', 'Header-B'],
+        max_age=600,
+        allow_credentials=True
+    ))
+    def custom_cors():
         return {'cors': True}
 
     @demo.route('/options', methods=['OPTIONS'])
@@ -127,6 +137,22 @@ def test_will_respond_with_cors_enabled(handler):
     handler.do_GET()
     response_lines = handler.wfile.getvalue().splitlines()
     assert b'Access-Control-Allow-Origin: *' in response_lines
+
+
+def test_will_respond_with_custom_cors_enabled(handler):
+    headers = {'content-type': 'application/json', 'origin': 'null'}
+    set_current_request(handler, method='GET', path='/custom_cors',
+                        headers=headers)
+    handler.do_GET()
+    response = handler.wfile.getvalue().splitlines()
+    print(response)
+    assert b'Access-Control-Allow-Origin: https://foo.bar' in response
+    assert (b'Access-Control-Allow-Headers: Authorization,Content-Type,'
+            b'Header-A,Header-B,X-Amz-Date,X-Amz-Security-Token,'
+            b'X-Api-Key') in response
+    assert b'Access-Control-Expose-Headers: Header-A,Header-B' in response
+    assert b'Access-Control-Max-Age: 600' in response
+    assert b'Access-Control-Allow-Credentials: true' in response
 
 
 def test_can_preflight_request(handler):


### PR DESCRIPTION
Allows specification of specific access control headers. Docs still
need to be written.

Implements: https://github.com/awslabs/chalice/issues/70#issuecomment-248787037