### PR TITLE
Fix content type validation when charset is provided

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Next Release (TBD)
 
 * Alway overwrite existing API Gateway Rest API on updates
   (`#305 <https://github.com/awslabs/chalice/issues/305>`__)
+* Fix content type validation when charset is provided
+  (`#306 <https://github.com/awslabs/chalice/issues/306>`__)
 
 
 0.8.0

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -299,7 +299,8 @@ class Chalice(object):
         if route_entry.content_types:
             content_type = self.current_request.headers.get(
                 'content-type', 'application/json')
-            if content_type not in route_entry.content_types:
+            if not self._matches_content_type(content_type,
+                                              route_entry.content_types):
                 return error_response(
                     error_code='UnsupportedMediaType',
                     message='Unsupported media type: %s' % content_type,
@@ -310,6 +311,11 @@ class Chalice(object):
         if self._cors_enabled_for_route(route_entry):
             self._add_cors_headers(response)
         return response.to_dict()
+
+    def _matches_content_type(self, content_type, valid_content_types):
+        if ';' in content_type:
+            content_type = content_type.split(';', 1)[0].strip()
+        return content_type in valid_content_types
 
     def _get_view_function_response(self, view_function, function_args):
         try:

--- a/tests/integration/test_features.py
+++ b/tests/integration/test_features.py
@@ -217,3 +217,11 @@ def test_api_key_required_fails_with_no_key(smoke_test_app):
     # Request should fail because we're not providing
     # an API key.
     assert response.status_code == 403
+
+
+def test_can_handle_charset(smoke_test_app):
+    url = smoke_test_app.url + '/json-only'
+    # Should pass content type validation even with charset specified.
+    response = requests.get(
+        url, headers={'Content-Type': 'application/json; charset=utf-8'})
+    assert response.status_code == 200

--- a/tests/integration/testapp/app.py
+++ b/tests/integration/testapp/app.py
@@ -68,6 +68,11 @@ def form_encoded():
     }
 
 
+@app.route('/json-only', content_types=['application/json'])
+def json_only():
+    return {'success': True}
+
+
 @app.route('/cors', methods=['GET', 'POST', 'PUT'], cors=True)
 def supports_cors():
     # It doesn't really matter what we return here because

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -305,6 +305,18 @@ def test_content_type_validation_raises_error_on_unknown_types():
     assert 'application/bad-xml' in json_response['Message']
 
 
+def test_content_type_with_charset():
+    demo = app.Chalice('demo-app')
+
+    @demo.route('/', content_types=['application/json'])
+    def index():
+        return {'foo': 'bar'}
+
+    event = create_event('/', 'GET', {}, 'application/json; charset=utf-8')
+    response = json_response_body(demo(event, context=None))
+    assert response == {'foo': 'bar'}
+
+
 def test_can_return_response_object():
     demo = app.Chalice('app-name')
 


### PR DESCRIPTION
The content types matching should only take into account the
type and subtype, not any of the content type parameters.

Content-Type grammar: https://tools.ietf.org/html/rfc7231#section-3.1.1.1
Fixes #185.