### PR TITLE
Add back dupe header fix in local mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@ Next Release (TBD)
   (`#305 <https://github.com/awslabs/chalice/issues/305>`__)
 * Added more granular support for CORS
   (`#311 <https://github.com/awslabs/chalice/pull/311>`__)
+* Fix duplicate content type header in local model
+  (`#311 <https://github.com/awslabs/chalice/issues/310>`__)
+
 
 0.8.0
 =====

--- a/chalice/local.py
+++ b/chalice/local.py
@@ -115,9 +115,9 @@ class ChaliceRequestHandler(BaseHTTPRequestHandler):
         # type: (EventType, Dict[str, Any]) -> None
         self.send_response(response['statusCode'])
         self.send_header('Content-Length', str(len(response['body'])))
-        self.send_header(
-            'Content-Type',
-            response['headers'].get('Content-Type', 'application/json'))
+        content_type = response['headers'].pop(
+            'Content-Type', 'application/json')
+        self.send_header('Content-Type', content_type)
         headers = response['headers']
         for header in headers:
             self.send_header(header, headers[header])

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -227,7 +227,7 @@ def test_content_type_included_once(handler):
     value = handler.wfile.getvalue()
     response_lines = value.splitlines()
     content_header_lines = [line for line in response_lines
-                            if line.startswith('Content-Type')]
+                            if line.startswith(b'Content-Type')]
     assert len(content_header_lines) == 1
 
 

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -1,4 +1,5 @@
 from chalice import local, BadRequestError, CORSConfig
+from chalice import Response
 import json
 import decimal
 import pytest
@@ -75,6 +76,12 @@ def sample_app():
     @demo.route('/query-string')
     def query_string():
         return demo.current_request.query_params
+
+    @demo.route('/custom-response')
+    def custom_response():
+        return Response(body='text',
+                        status_code=200,
+                        headers={'Content-Type': 'text/plain'})
 
     return demo
 
@@ -212,6 +219,16 @@ def test_querystring_is_mapped(handler):
     set_current_request(handler, method='GET', path='/query-string?a=b&c=d')
     handler.do_GET()
     assert _get_body_from_response_stream(handler) == {'a': 'b', 'c': 'd'}
+
+
+def test_content_type_included_once(handler):
+    set_current_request(handler, method='GET', path='/custom-response')
+    handler.do_GET()
+    value = handler.wfile.getvalue()
+    response_lines = value.splitlines()
+    content_header_lines = [line for line in response_lines
+                            if line.startswith('Content-Type')]
+    assert len(content_header_lines) == 1
 
 
 @pytest.mark.parametrize('actual_url,matched_url', [


### PR DESCRIPTION
Brings back https://github.com/awslabs/chalice/pull/314 and adds a fix for the tests in py3.