### PR TITLE
Run tests on py3 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,17 @@ language: python
 sudo: false
 matrix:
   include:
-  - python: "3.5"
+  - python: "3.6"
     env: TEST_TYPE=typecheck
+  - python: "3.6"
+    env: TEST_TYPE=coverage
   - python: "2.7"
     env: TEST_TYPE=coverage
   - python: "2.7"
     env: TEST_TYPE=check
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION != 3.* ]]; then pip install -e . ; fi
-  - if [[ $TRAVIS_PYTHON_VERSION != 3.* ]]; then travis_retry pip install -r requirements-dev.txt; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then pip install  mypy==0.501; fi
+  - pip install -r requirements-dev.txt
+  - pip install -e .
 script:
   - make $TEST_TYPE
 after_success:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,20 @@
+# Dev requirements, used for various linting tools
 coverage==4.0.3
 flake8==2.5.0
 tox==2.2.1
 wheel==0.26.0
 doc8==0.7.0
+# Pylint will fail on py3.  Locking to a commit on master
+# until pylint2 is released.
 -e git://github.com/PyCQA/pylint.git@7cb3ffddfd96f5e099ca697f6b1e30e727544627#egg=pylint
 pytest-cov==2.3.1
 pydocstyle==1.0.0
--r requirements-test.txt
+
+# Test requirements
+pytest==3.0.3
+py==1.4.31
+pygments==2.1.3
+mock==2.0.0
+requests==2.11.1
+
+mypy==0.501; python_version >= '3.6'

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,0 @@
-pytest==3.0.3
-py==1.4.31
-pygments==2.1.3
-mock==2.0.0
-requests==2.11.1


### PR DESCRIPTION
To do this, I've simplified the requirements.txt
file to consolidate all requirements into a single dev
requirements file.  The distinction with requirements-test
isn't useful anymore, the linting is run on travis
anyways.

