### PR TITLE
Pass user provided api gateway stage to config

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -116,7 +116,9 @@ def deploy(ctx, autogen_policy, profile, api_gateway_stage, stage,
     factory = ctx.obj['factory']  # type: CLIFactory
     factory.profile = profile
     config = factory.create_config_obj(
-        chalice_stage_name=stage, autogen_policy=autogen_policy)
+        chalice_stage_name=stage, autogen_policy=autogen_policy,
+        api_gateway_stage=api_gateway_stage,
+    )
     session = factory.create_botocore_session()
     d = factory.create_default_deployer(session=session, prompter=click)
     deployed_values = d.deploy(config, chalice_stage_name=stage)

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -203,6 +203,21 @@ def test_api_gateway_mutex_with_positional_arg(runner, mock_cli_factory,
     assert not mock_deployer.deploy.called
 
 
+def test_can_specify_api_gateway_stage(runner, mock_cli_factory,
+                                       mock_deployer):
+    with runner.isolated_filesystem():
+        cli.create_new_project_skeleton('testproject')
+        os.chdir('testproject')
+        result = _run_cli_command(runner, cli.deploy,
+                                  ['--api-gateway-stage', 'notdev'],
+                                  cli_factory=mock_cli_factory)
+        assert result.exit_code == 0
+        mock_cli_factory.create_config_obj.assert_called_with(
+            autogen_policy=True, chalice_stage_name='dev',
+            api_gateway_stage='notdev'
+        )
+
+
 def test_can_retrieve_url(runner, mock_cli_factory):
     deployed_values = {
         "dev": {


### PR DESCRIPTION
We weren't passing this value to the factory obj
when creating the config so --api-gateway-stage
was being ignored.

cc @stealthycoin 