### PR TITLE
Bump package requirements to latest versions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,18 +1,18 @@
 # Dev requirements, used for various linting tools
-coverage==4.0.3
-flake8==2.5.0
+coverage==4.3.4
+flake8==3.3.0
 tox==2.2.1
 wheel==0.26.0
 doc8==0.7.0
 # Pylint will fail on py3.  Locking to a commit on master
 # until pylint2 is released.
 -e git://github.com/PyCQA/pylint.git@7cb3ffddfd96f5e099ca697f6b1e30e727544627#egg=pylint
-pytest-cov==2.3.1
-pydocstyle==1.0.0
+pytest-cov==2.4.0
+pydocstyle==2.0.0
 
 # Test requirements
-pytest==3.0.3
-py==1.4.31
+pytest==3.0.7
+py==1.4.33
 pygments==2.1.3
 mock==2.0.0
 requests==2.11.1


### PR DESCRIPTION
pydocstyle: http://www.pydocstyle.org/en/latest/release_notes.html
flake8: http://flake8.pycqa.org/en/latest/release-notes/3.0.0.html
coverage: https://bitbucket.org/ned/coveragepy/src/tip/CHANGES.rst

This came about because the version of coverage we were using
was broken for python3.  It would report 100% coverage and only
report on the __init__.py files.  The latest version of coverage
fixes this.