### PR TITLE
Tag deployed lambda functions

### DIFF
--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -66,7 +66,7 @@ class TypedAWSClient(object):
     def create_function(self, function_name, role_arn, zip_contents,
                         environment_variables=None, runtime='python2.7',
                         tags=None):
-        # type: (str, str, str, _STR_MAP, str, Optional[Dict[str, str]]) -> str
+        # type: (str, str, str, _STR_MAP, str, _STR_MAP) -> str
         kwargs = {
             'FunctionName': function_name,
             'Runtime': runtime,

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -5,6 +5,7 @@ import hashlib
 
 from typing import Any, Dict  # noqa
 
+from chalice import __version__ as chalice_version
 from chalice.deploy.swagger import CFNSwaggerGenerator
 from chalice.deploy.swagger import SwaggerGenerator  # noqa
 from chalice.deploy.packager import LambdaDeploymentPackager
@@ -103,6 +104,7 @@ class SAMTemplateGenerator(object):
             'CodeUri': code_uri,
             'Events': self._generate_function_events(config.chalice_app),
             'Policies': [self._generate_iam_policy()],
+            'Tags': self._function_tags(config),
         }
         if config.environment_variables:
             properties['Environment'] = {
@@ -112,6 +114,13 @@ class SAMTemplateGenerator(object):
             'Type': 'AWS::Serverless::Function',
             'Properties': properties,
         }
+
+    def _function_tags(self, config):
+        # type: (Config) -> Dict[str, str]
+        tag = 'version=%s:stage=%s:app=%s' % (chalice_version,
+                                              config.chalice_stage,
+                                              config.app_name)
+        return {'aws-chalice': tag}
 
     def _generate_function_events(self, app):
         # type: (Chalice) -> Dict[str, Any]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.rst') as readme_file:
 
 install_requires = [
     'click==6.6',
-    'botocore>=1.5.0,<2.0.0',
+    'botocore>=1.5.40,<2.0.0',
     'virtualenv>=15.0.0,<16.0.0',
     'typing==3.5.3.0',
     'six>=1.10.0,<2.0.0',

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -421,6 +421,25 @@ class TestCreateLambdaFunction(object):
             awsclient.create_function('name', 'myarn', b'foo')
         stubbed_session.verify_stubs()
 
+    def test_can_provide_tags(self, stubbed_session):
+        stubbed_session.stub('lambda').create_function(
+            FunctionName='name',
+            Runtime='python2.7',
+            Code={'ZipFile': b'foo'},
+            Handler='app.app',
+            Role='myarn',
+            Timeout=60,
+            Tags={'key': 'value'},
+        ).returns({'FunctionArn': 'arn:12345:name'})
+        stubbed_session.activate_stubs()
+        awsclient = TypedAWSClient(stubbed_session)
+        assert awsclient.create_function(
+            function_name='name',
+            role_arn='myarn',
+            zip_contents=b'foo',
+            tags={'key': 'value'}) == 'arn:12345:name'
+        stubbed_session.verify_stubs()
+
 
 class TestCanDeleteRolePolicy(object):
     def test_can_delete_role_policy(self, stubbed_session):

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -476,7 +476,10 @@ def test_lambda_deployer_repeated_deploy(app_policy, sample_app):
     # And should result in the lambda function being updated with the API.
     aws_client.update_function.assert_called_with(
         lambda_function_name, b'package contents', {"FOO": "BAR"},
-        cfg.lambda_python_version)
+        cfg.lambda_python_version,
+        {'aws-chalice': 'version=%s:stage=%s:app=%s' % (chalice_version,
+                                                        'dev', 'appname')}
+    )
 
 
 def test_lambda_deployer_delete():
@@ -576,7 +579,9 @@ def test_lambda_deployer_initial_deploy(app_policy, sample_app):
     }
     aws_client.create_function.assert_called_with(
         'myapp-dev', 'role-arn', b'package contents',
-        {"FOO": "BAR"}, cfg.lambda_python_version)
+        {"FOO": "BAR"}, cfg.lambda_python_version,
+        {'aws-chalice': 'version=%s:stage=dev:app=myapp' % chalice_version}
+    )
 
 
 def test_cant_have_options_with_cors(sample_app):


### PR DESCRIPTION
Makes it possible for customers to easily see
which lambda functions are used for chalice.
Also opens up the possibility of us not having
to rely on the local deployed.json.  That would
be future work though.  This commit
only adds support for tagging the functions.

The format uses colon separated values because
Lambda does not allow CSV values for the value
of a tag.

I also bumped the min version of botocore to the
version where tagging support was added to lambda.