### PR TITLE
Fix importing vendor lib during config creation.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,8 @@ Next Release (TBD)
   (`#351 <https://github.com/awslabs/chalice/pull/351>`__)
 * Add support for ``tags`` configuration
   (`#351 <https://github.com/awslabs/chalice/pull/351>`__)
-
+* Fix vendor directory contents not being importable locally
+  (`#350 <https://github.com/awslabs/chalice/pull/350>`__)
 
 0.8.2
 =====

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -131,6 +131,15 @@ class CLIFactory(object):
         # type: () -> Chalice
         if self.project_dir not in sys.path:
             sys.path.insert(0, self.project_dir)
+        # The vendor directory has its contents copied up to the top level of
+        # the deployment package. This means that imports will work in the
+        # lambda function as if the vendor directory is on the python path.
+        # For loading the config locally we must add the vendor directory to
+        # the path so it will be treated the same as if it were running on
+        # lambda.
+        vendor_dir = os.path.join(self.project_dir, 'vendor')
+        if os.path.isdir(vendor_dir):
+            sys.path.insert(0, vendor_dir)
         try:
             app = importlib.import_module('app')
             chalice_app = getattr(app, 'app')

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -138,7 +138,7 @@ class CLIFactory(object):
         # the path so it will be treated the same as if it were running on
         # lambda.
         vendor_dir = os.path.join(self.project_dir, 'vendor')
-        if os.path.isdir(vendor_dir):
+        if os.path.isdir(vendor_dir) and vendor_dir not in sys.path:
             sys.path.insert(0, vendor_dir)
         try:
             app = importlib.import_module('app')

--- a/tests/functional/cli/test_factory.py
+++ b/tests/functional/cli/test_factory.py
@@ -104,15 +104,11 @@ def test_can_import_vendor_package(clifactory):
     vendedlib_dir = os.path.join(clifactory.project_dir, 'vendor', 'vendedlib')
     os.makedirs(vendedlib_dir)
     open(os.path.join(vendedlib_dir, '__init__.py'), 'a').close()
-    with open(os.path.join(vendedlib_dir, 'utils.py'), 'w') as f:
-        f.write(
-            'def data_getter():\n'
-            '    return "some data value"\n'
-        )
+    open(os.path.join(vendedlib_dir, 'submodule.py'), 'a').close()
     app_py = os.path.join(clifactory.project_dir, 'app.py')
     with open(app_py, 'r+') as f:
         data = f.read()
         f.seek(0, 0)
-        f.write('from vendedlib.utils import data_getter\n%s' % data)
+        f.write('from vendedlib import submodule\n%s' % data)
     config = clifactory.create_config_obj()
     assert isinstance(config, Config)

--- a/tests/functional/cli/test_factory.py
+++ b/tests/functional/cli/test_factory.py
@@ -104,11 +104,14 @@ def test_can_import_vendor_package(clifactory):
     vendedlib_dir = os.path.join(clifactory.project_dir, 'vendor', 'vendedlib')
     os.makedirs(vendedlib_dir)
     open(os.path.join(vendedlib_dir, '__init__.py'), 'a').close()
-    open(os.path.join(vendedlib_dir, 'submodule.py'), 'a').close()
+    with open(os.path.join(vendedlib_dir, 'submodule.py'), 'a') as f:
+        f.write('CONST = "foo bar"\n')
     app_py = os.path.join(clifactory.project_dir, 'app.py')
     with open(app_py, 'r+') as f:
         data = f.read()
         f.seek(0, 0)
         f.write('from vendedlib import submodule\n%s' % data)
-    config = clifactory.create_config_obj()
-    assert isinstance(config, Config)
+        f.seek(0, 1)
+        f.write('app.imported_value = submodule.CONST')
+    app = clifactory.load_chalice_app()
+    assert app.imported_value == 'foo bar'

--- a/tests/functional/cli/test_factory.py
+++ b/tests/functional/cli/test_factory.py
@@ -107,11 +107,8 @@ def test_can_import_vendor_package(clifactory):
     with open(os.path.join(vendedlib_dir, 'submodule.py'), 'a') as f:
         f.write('CONST = "foo bar"\n')
     app_py = os.path.join(clifactory.project_dir, 'app.py')
-    with open(app_py, 'r+') as f:
-        data = f.read()
-        f.seek(0, 0)
-        f.write('from vendedlib import submodule\n%s' % data)
-        f.seek(0, 1)
-        f.write('app.imported_value = submodule.CONST')
+    with open(app_py, 'a') as f:
+        f.write('from vendedlib import submodule\n')
+        f.write('app.imported_value = submodule.CONST\n')
     app = clifactory.load_chalice_app()
     assert app.imported_value == 'foo bar'

--- a/tests/functional/cli/test_factory.py
+++ b/tests/functional/cli/test_factory.py
@@ -97,3 +97,22 @@ def test_filename_and_lineno_included_in_syntax_error(clifactory):
     message = str(excinfo.value)
     assert 'app.py' in message
     assert 'line 1' in message
+
+
+def test_can_import_vendor_package(clifactory):
+    # Tests that vendor packages can be imported during config loading.
+    vendedlib_dir = os.path.join(clifactory.project_dir, 'vendor', 'vendedlib')
+    os.makedirs(vendedlib_dir)
+    open(os.path.join(vendedlib_dir, '__init__.py'), 'a').close()
+    with open(os.path.join(vendedlib_dir, 'utils.py'), 'w') as f:
+        f.write(
+            'def data_getter():\n'
+            '    return "some data value"\n'
+        )
+    app_py = os.path.join(clifactory.project_dir, 'app.py')
+    with open(app_py, 'r+') as f:
+        data = f.read()
+        f.seek(0, 0)
+        f.write('from vendedlib.utils import data_getter\n%s' % data)
+    config = clifactory.create_config_obj()
+    assert isinstance(config, Config)


### PR DESCRIPTION
Adds the vendor directory to the path when loading the app locally. This
is required for both deployment and local testing since both commands
load the app.py file, which will fail if anything is imported from the
vendor directory without it being added to the pythonpath. fixes #349 

I also manually tested `chalice deploy` and `chalice local`

cc @jamesls @kyleknap 