### PR TITLE
Added support for binary payloads.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,9 @@ Next Release (TBD)
   (`#351 <https://github.com/awslabs/chalice/pull/351>`__)
 * Fix vendor directory contents not being importable locally
   (`#350 <https://github.com/awslabs/chalice/pull/350>`__)
+* Add support for binary payloads
+  (`#352 <https://github.com/awslabs/chalice/pull/352>`__)
+
 
 0.8.2
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Next Release (TBD)
 * Fix vendor directory contents not being importable locally
   (`#350 <https://github.com/awslabs/chalice/pull/350>`__)
 * Add support for binary payloads
-  (`#352 <https://github.com/awslabs/chalice/pull/352>`__)
+  (`#348 <https://github.com/awslabs/chalice/issues/348>`__)
 
 
 0.8.2

--- a/README.rst
+++ b/README.rst
@@ -706,62 +706,6 @@ This will result in a plain text response body::
     hello world!
 
 
-Tutorial: Binary Content
-========================
-
-Chalice supports binary payloads through its ``app.api.binary_types`` list. Any
-type in this list is considered a binary ``Content-Type``. Whenever a request
-with a ``Content-Type`` header is encountered that matches an entry in the
-``binary_types`` list, its body will be available as a ``bytes`` type on the
-property ``app.current_request.raw_body``. Similarly, in order to send binary
-data back in a response, simply set your ``Content-Type`` header to something
-present in the ``binary_types`` list. Note that you can override the default
-types by modifying the ``app.api.binary_types`` list at the module level.
-
-Here is an example app which simply echos back binary content:
-
-.. code-block:: python
-
-   from chalice import Chalice, Response
-
-   app = Chalice(app_name="binary-response")
-
-   @app.route('/bin-echo', methods=['POST'],
-              content_types=['application/octet-stream'])
-   def bin_echo():
-       raw_request_body = app.current_request.raw_body
-       return Response(body=raw_request_body,
-                       status_code=200,
-		       headers={'Content-Type': 'application/octet-stream'})
-
-You can see this app echo back binary data sent to it::
-
-  $ echo -n -e "\xFE\xED" | http POST $(chalice url)bin-echo Accept:application/octet-stream Content-Type:application/octet-stream | xxd
-  0000000: feed                                     ..
-
-Note that both the ``Accept`` and ``Content-Type`` header are required. If
-you fail to set the ``Content-Type`` header on the request will result in a
-``415 UnsupportedMediaType`` error. Care must be taken when configuring what
-``content_types`` a route accepts, they must all be valid binary types, or they
-must all be non-binary types. The ``Accept`` header must also be set if the
-data returned is to be the raw binary, if is omitted the call will succeed but
-a base64 encoding of the binary will be sent back instead of the bytes expected
-.
-
-For example::
-
-  $ echo -n -e "\xFE\xED" | http POST  $(chalice url)bin-echo Content-Type:application/octet-stream
-  HTTP/1.1 200 OK
-  Connection: keep-alive
-  Content-Length: 4
-  Content-Type: application/octet-stream
-
-  /u0=
-
-This results in the payload being larger than the acutal binary since base64
-encoding results in data being roughly ``4/3`` the size of the original data.
-
-
 Tutorial: CORS Support
 ======================
 

--- a/README.rst
+++ b/README.rst
@@ -706,6 +706,62 @@ This will result in a plain text response body::
     hello world!
 
 
+Tutorial: Binary Content
+========================
+
+Chalice supports binary payloads through its ``app.api.binary_types`` list. Any
+type in this list is considered a binary ``Content-Type``. Whenever a request
+with a ``Content-Type`` header is encountered that matches an entry in the
+``binary_types`` list, its body will be available as a ``bytes`` type on the
+property ``app.current_request.raw_body``. Similarly, in order to send binary
+data back in a response, simply set your ``Content-Type`` header to something
+present in the ``binary_types`` list. Note that you can override the default
+types by modifying the ``app.api.binary_types`` list at the module level.
+
+Here is an example app which simply echos back binary content:
+
+.. code-block:: python
+
+   from chalice import Chalice, Response
+
+   app = Chalice(app_name="binary-response")
+
+   @app.route('/bin-echo', methods=['POST'],
+              content_types=['application/octet-stream'])
+   def bin_echo():
+       raw_request_body = app.current_request.raw_body
+       return Response(body=raw_request_body,
+                       status_code=200,
+		       headers={'Content-Type': 'application/octet-stream'})
+
+You can see this app echo back binary data sent to it::
+
+  $ echo -n -e "\xFE\xED" | http POST $(chalice url)bin-echo Accept:application/octet-stream Content-Type:application/octet-stream | xxd
+  0000000: feed                                     ..
+
+Note that both the ``Accept`` and ``Content-Type`` header are required. If
+you fail to set the ``Content-Type`` header on the request will result in a
+``415 UnsupportedMediaType`` error. Care must be taken when configuring what
+``content_types`` a route accepts, they must all be valid binary types, or they
+must all be non-binary types. The ``Accept`` header must also be set if the
+data returned is to be the raw binary, if is omitted the call will succeed but
+a base64 encoding of the binary will be sent back instead of the bytes expected
+.
+
+For example::
+
+  $ echo -n -e "\xFE\xED" | http POST  $(chalice url)bin-echo Content-Type:application/octet-stream
+  HTTP/1.1 200 OK
+  Connection: keep-alive
+  Content-Length: 4
+  Content-Type: application/octet-stream
+
+  /u0=
+
+This results in the payload being larger than the acutal binary since base64
+encoding results in data being roughly ``4/3`` the size of the original data.
+
+
 Tutorial: CORS Support
 ======================
 

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -556,10 +556,14 @@ class Chalice(object):
         request_accept_header = request_headers.get('accept')
         response_content_type = response_headers.get(
             'content-type', 'application/json')
-        response_is_binary = response_content_type in self.api.binary_types
-        request_accepts_binary = request_accept_header in self.api.binary_types
-        if response_is_binary != request_accepts_binary:
-            return False
+        response_is_binary = _matches_content_type(response_content_type,
+                                                   self.api.binary_types)
+        expects_binary_response = False
+        if request_accept_header is not None:
+            expects_binary_response = _matches_content_type(request_accept_header,
+                                                            self.api.binary_types)
+        if response_is_binary and not expects_binary_response:
+                return False
         return True
 
     def _get_view_function_response(self, view_function, function_args):

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -29,7 +29,7 @@ def prepare_response_for_apigateway(response, binary_types):
     # byte sequence if the content type is application/json before being
     # converted to a base64 string.
     if _matches_content_type(content_type, binary_types):
-        if content_type.startswith('application/json'):
+        if _matches_content_type(content_type, ['application/json']):
             body = body.encode('utf-8')
         body = _base64encode(body)
         response_dict['isBase64Encoded'] = True

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -294,7 +294,7 @@ class Response(object):
 
     def to_dict(self, binary_types=None):
         body = self.body
-        if not isinstance(body, str) and not isinstance(body, bytes):
+        if not isinstance(body, (str, bytes)):
             body = json.dumps(body, default=handle_decimals)
         response = {
             'headers': self.headers,

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -310,12 +310,13 @@ class Response(object):
         content_type = response_headers.get('content-type', '')
         body = response_dict['body']
 
-        # Encode the response as binary if required.
-        # To keep json types working as expected they are encoded to a utf-8
-        # byte sequence if the content type is application/json before being
-        # converted to a base64 string.
         if _matches_content_type(content_type, binary_types):
             if _matches_content_type(content_type, ['application/json']):
+                # There's a special case when a user configures
+                # ``application/json`` as a binary type.  The default
+                # json serialization results in a string type, but for binary
+                # content types we need a type bytes().  So we need to special
+                # case this scenario and encode the JSON body to bytes().
                 body = body.encode('utf-8')
             body = self._base64encode(body)
             response_dict['isBase64Encoded'] = True

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -561,10 +561,10 @@ class Chalice(object):
                                                    self.api.binary_types)
         expects_binary_response = False
         if request_accept_header is not None:
-            expects_binary_response = _matches_content_type(request_accept_header,
-                                                            self.api.binary_types)
+            expects_binary_response = _matches_content_type(
+                request_accept_header, self.api.binary_types)
         if response_is_binary and not expects_binary_response:
-                return False
+            return False
         return True
 
     def _get_view_function_response(self, view_function, function_args):

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -94,8 +94,13 @@ class RouteEntry(object):
     def __eq__(self, other: object) -> bool: ...
 
 
+class APIGateway(object):
+    binary_types = ... # type: List[str]
+
+
 class Chalice(object):
     app_name = ... # type: str
+    api = ... # type: APIGateway
     routes = ... # type: Dict[str, RouteEntry]
     current_request = ... # type: Request
     debug = ... # type: bool

--- a/chalice/deploy/swagger.py
+++ b/chalice/deploy/swagger.py
@@ -32,8 +32,13 @@ class SwaggerGenerator(object):
         # type: (Chalice) -> Dict[str, Any]
         api = copy.deepcopy(self._BASE_TEMPLATE)
         api['info']['title'] = app.app_name
+        self._add_binary_types(api, app)
         self._add_route_paths(api, app)
         return api
+
+    def _add_binary_types(self, api, app):
+        # type: (Dict[str, Any], Chalice) -> None
+        api['x-amazon-apigateway-binary-media-types'] = app.api.binary_types
 
     def _add_route_paths(self, api, app):
         # type: (Dict[str, Any], Chalice) -> None

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -16,6 +16,12 @@ Chalice
       a view function is being called.  This attribute can be used to
       introspect the current HTTP request.
 
+   .. attribute:: api
+
+      An object of type :class:`APIGateway`. This attribute can be used to control
+      how apigateway interprets ``Content-Type`` headers in both requests and
+      responses.
+
    .. attribute:: debug
 
       A boolean value that enables debugging.  By default, this value is
@@ -249,6 +255,47 @@ for an ``@app.route(authorizer=...)`` call:
   .. attribute:: header
 
      The header where the auth token will be specified.
+
+
+APIGateway
+==========
+
+There is a single instance of :class:`APIGateway` attached to each
+:class:`Chalice` object under the ``api`` attribute.
+
+.. attribute:: default_binary_types
+
+   The value of ``default_binary_types`` are the ``Content-Types`` that are
+   considered binary by default. This value should not be changed, instead you
+   should modify the ``binary_types`` list to change the behavior of a content
+   type.
+
+.. attribute:: binary_types
+
+   The value of ``binary_types`` controls how API Gateway interprets requests
+   and responses as detailed below.
+
+   If an incoming request has a ``Content-Type`` header value that is present
+   in the ``binary_types`` list it will be assumed that its body is a sequence
+   of raw bytes. You can access these bytes by accessing the
+   ``app.current_request.raw_body`` property.
+
+   If an outgoing response from ``Chalice`` has a header ``Content-Type`` that
+   matches one of the ``binary_types`` its body must be a ``bytes`` type object.
+   It is important to note that originating request must have the ``Accept``
+   header for the same type as the ``Content-Type`` on the response. Otherwise
+   a ``400`` error will be returned.
+
+   Implementation note: API Gateway and Lambda communicate through a JSON event
+   which is encoded using ``UTF-8``. The raw bytes are temporarily encoded
+   using
+
+   base64 when being passed between API Gateway and Labmda. In the worst case
+   this encoding can cause the binary body to be inflated up to ``4/3`` its
+   original size. Lambda only accepts an event up to ``6mb``, which means even
+   if your binary data was not quite at that limit, with the base64 encoding it
+   may exceed that limit. This will manifest as a ``502`` Bad Gateway error.
+
 
 CORS
 ====

--- a/tests/integration/test_features.py
+++ b/tests/integration/test_features.py
@@ -214,6 +214,19 @@ def test_form_encoded_content_type(smoke_test_app):
     assert response.json() == {'parsed': {'foo': ['bar']}}
 
 
+def test_can_round_trip_binary(smoke_test_app):
+    # xde xed xbe xef will fail unicode decoding because xbe is an invalid
+    # start byte in utf-8.
+    bin_data = b'\xDE\xAD\xBE\xEF'
+    response = requests.post(smoke_test_app.url + '/binary',
+                             headers={
+                                 'Content-Type': 'application/octet-stream',
+                                 'Accept': 'application/octet-stream',
+                             },
+                             data=bin_data)
+    assert response.content == bin_data
+
+
 def test_can_support_cors(smoke_test_app):
     response = requests.get(smoke_test_app.url + '/cors')
     response.raise_for_status()

--- a/tests/integration/test_features.py
+++ b/tests/integration/test_features.py
@@ -227,6 +227,17 @@ def test_can_round_trip_binary(smoke_test_app):
     assert response.content == bin_data
 
 
+def test_can_round_trip_binary_custom_content_type(smoke_test_app):
+    bin_data = b'\xDE\xAD\xBE\xEF'
+    response = requests.post(smoke_test_app.url + '/custom-binary',
+                             headers={
+                                 'Content-Type': 'application/binary',
+                                 'Accept': 'application/binary',
+                             },
+                             data=bin_data)
+    assert response.content == bin_data
+
+
 def test_can_support_cors(smoke_test_app):
     response = requests.get(smoke_test_app.url + '/cors')
     response.raise_for_status()

--- a/tests/integration/testapp/app.py
+++ b/tests/integration/testapp/app.py
@@ -1,128 +1,43 @@
-from chalice import Chalice, BadRequestError, NotFoundError, Response,\
-    CORSConfig
+"""Test app redeploy.
 
-try:
-    from urllib.parse import parse_qs
-except:
-    from urlparse import parse_qs
+This file is copied over to app.py during the integration
+tests to test behavior on redeploys.
 
-# This is a test app that is used by integration tests.
-# This app exercises all the major features of chalice
-# and helps prevent regressions.
+"""
+from chalice import Chalice
+
 
 app = Chalice(app_name='smoketestapp')
 
 
+# Test an unchanged view, this is the exact
+# version from app.py
 @app.route('/')
 def index():
     return {'hello': 'world'}
 
 
+# Test same route info but changed view code.
 @app.route('/a/b/c/d/e/f/g')
 def nested_route():
-    return {'nested': True}
+    return {'redeployed': True}
 
 
-@app.route('/path/{name}')
-def supports_path_params(name):
-    return {'path': name}
+# Test route deletion.  This view is in the original
+# app.py but is now deleted.
+# @app.route('/path/{name}')
+# def supports_path_params(name):
+#     return {'path': name}
 
-
-@app.route('/post', methods=['POST'])
-def supports_only_post():
-    return {'success': True}
-
-
-@app.route('/put', methods=['PUT'])
-def supports_only_put():
-    return {'success': True}
-
-
-@app.route('/jsonpost', methods=['POST'])
-def supports_post_body_as_json():
-    json_body = app.current_request.json_body
-    return {'json_body': json_body}
-
-
-@app.route('/multimethod', methods=['GET', 'POST'])
+# Test route modification with the same view code.
+# The original version had methods=['GET', 'POST']
+@app.route('/multimethod', methods=['GET', 'PUT'])
 def multiple_methods():
     return {'method': app.current_request.method}
 
 
-@app.route('/badrequest')
-def bad_request_error():
-    raise BadRequestError("Bad request.")
-
-
-@app.route('/notfound')
-def not_found_error():
-    raise NotFoundError("Not found")
-
-
-@app.route('/arbitrary-error')
-def raise_arbitrary_error():
-    raise TypeError("Uncaught exception")
-
-
-@app.route('/formencoded', methods=['POST'],
-           content_types=['application/x-www-form-urlencoded'])
-def form_encoded():
-    parsed = parse_qs(app.current_request.raw_body)
-    return {
-        'parsed': parsed
-    }
-
-
-@app.route('/binary', methods=['POST'],
-           content_types=['application/octet-stream'])
-def binary_round_trip():
-    return Response(
-        app.current_request.raw_body,
-        headers={
-            'Content-Type': 'application/octet-stream'
-        },
-        status_code=200)
-
-
-@app.route('/json-only', content_types=['application/json'])
-def json_only():
+# Test new view function added that wasn't in the original
+# app.py file.
+@app.route('/redeploy')
+def redeploy():
     return {'success': True}
-
-
-@app.route('/cors', methods=['GET', 'POST', 'PUT'], cors=True)
-def supports_cors():
-    # It doesn't really matter what we return here because
-    # we'll be checking the response headers to verify CORS support.
-    return {'cors': True}
-
-
-@app.route('/custom_cors', methods=['GET', 'POST', 'PUT'], cors=CORSConfig(
-    allow_origin='https://foo.example.com',
-    allow_headers=['X-Special-Header'],
-    max_age=600,
-    expose_headers=['X-Special-Header'],
-    allow_credentials=True))
-def supports_custom_cors():
-    return {'cors': True}
-
-
-@app.route('/todict', methods=['GET'])
-def todict():
-    return app.current_request.to_dict()
-
-
-@app.route('/multifile')
-def multifile():
-    from chalicelib import MESSAGE
-    return {"message": MESSAGE}
-
-
-@app.route('/custom-response', methods=['GET'])
-def custom_response():
-    return Response(status_code=204, body='',
-                    headers={'Content-Type': 'text/plain'})
-
-
-@app.route('/api-key-required', methods=['GET'], api_key_required=True)
-def api_key_required():
-    return {"success": True}

--- a/tests/integration/testapp/app.py
+++ b/tests/integration/testapp/app.py
@@ -73,6 +73,17 @@ def form_encoded():
     }
 
 
+@app.route('/binary', methods=['POST'],
+           content_types=['application/octet-stream'])
+def binary_round_trip():
+    return Response(
+        app.current_request.raw_body,
+        headers={
+            'Content-Type': 'application/octet-stream'
+        },
+        status_code=200)
+
+
 @app.route('/json-only', content_types=['application/json'])
 def json_only():
     return {'success': True}

--- a/tests/integration/testapp/app.py
+++ b/tests/integration/testapp/app.py
@@ -1,43 +1,140 @@
-"""Test app redeploy.
+from chalice import Chalice, BadRequestError, NotFoundError, Response,\
+    CORSConfig
 
-This file is copied over to app.py during the integration
-tests to test behavior on redeploys.
+try:
+    from urllib.parse import parse_qs
+except:
+    from urlparse import parse_qs
 
-"""
-from chalice import Chalice
-
+# This is a test app that is used by integration tests.
+# This app exercises all the major features of chalice
+# and helps prevent regressions.
 
 app = Chalice(app_name='smoketestapp')
+app.api.binary_types.append('application/binary')
 
 
-# Test an unchanged view, this is the exact
-# version from app.py
 @app.route('/')
 def index():
     return {'hello': 'world'}
 
 
-# Test same route info but changed view code.
 @app.route('/a/b/c/d/e/f/g')
 def nested_route():
-    return {'redeployed': True}
+    return {'nested': True}
 
 
-# Test route deletion.  This view is in the original
-# app.py but is now deleted.
-# @app.route('/path/{name}')
-# def supports_path_params(name):
-#     return {'path': name}
+@app.route('/path/{name}')
+def supports_path_params(name):
+    return {'path': name}
 
-# Test route modification with the same view code.
-# The original version had methods=['GET', 'POST']
-@app.route('/multimethod', methods=['GET', 'PUT'])
+
+@app.route('/post', methods=['POST'])
+def supports_only_post():
+    return {'success': True}
+
+
+@app.route('/put', methods=['PUT'])
+def supports_only_put():
+    return {'success': True}
+
+
+@app.route('/jsonpost', methods=['POST'])
+def supports_post_body_as_json():
+    json_body = app.current_request.json_body
+    return {'json_body': json_body}
+
+
+@app.route('/multimethod', methods=['GET', 'POST'])
 def multiple_methods():
     return {'method': app.current_request.method}
 
 
-# Test new view function added that wasn't in the original
-# app.py file.
-@app.route('/redeploy')
-def redeploy():
+@app.route('/badrequest')
+def bad_request_error():
+    raise BadRequestError("Bad request.")
+
+
+@app.route('/notfound')
+def not_found_error():
+    raise NotFoundError("Not found")
+
+
+@app.route('/arbitrary-error')
+def raise_arbitrary_error():
+    raise TypeError("Uncaught exception")
+
+
+@app.route('/formencoded', methods=['POST'],
+           content_types=['application/x-www-form-urlencoded'])
+def form_encoded():
+    parsed = parse_qs(app.current_request.raw_body)
+    return {
+        'parsed': parsed
+    }
+
+
+@app.route('/json-only', content_types=['application/json'])
+def json_only():
     return {'success': True}
+
+
+@app.route('/cors', methods=['GET', 'POST', 'PUT'], cors=True)
+def supports_cors():
+    # It doesn't really matter what we return here because
+    # we'll be checking the response headers to verify CORS support.
+    return {'cors': True}
+
+
+@app.route('/custom_cors', methods=['GET', 'POST', 'PUT'], cors=CORSConfig(
+    allow_origin='https://foo.example.com',
+    allow_headers=['X-Special-Header'],
+    max_age=600,
+    expose_headers=['X-Special-Header'],
+    allow_credentials=True))
+def supports_custom_cors():
+    return {'cors': True}
+
+
+@app.route('/todict', methods=['GET'])
+def todict():
+    return app.current_request.to_dict()
+
+
+@app.route('/multifile')
+def multifile():
+    from chalicelib import MESSAGE
+    return {"message": MESSAGE}
+
+
+@app.route('/custom-response', methods=['GET'])
+def custom_response():
+    return Response(status_code=204, body='',
+                    headers={'Content-Type': 'text/plain'})
+
+
+@app.route('/api-key-required', methods=['GET'], api_key_required=True)
+def api_key_required():
+    return {"success": True}
+
+
+@app.route('/binary', methods=['POST'],
+           content_types=['application/octet-stream'])
+def binary_round_trip():
+    return Response(
+        app.current_request.raw_body,
+        headers={
+            'Content-Type': 'application/octet-stream'
+        },
+        status_code=200)
+
+
+@app.route('/custom-binary', methods=['POST'],
+           content_types=['application/binary'])
+def custom_binary_round_trip():
+    return Response(
+        app.current_request.raw_body,
+        headers={
+            'Content-Type': 'application/binary'
+        },
+        status_code=200)

--- a/tests/integration/testapp/app.py
+++ b/tests/integration/testapp/app.py
@@ -68,7 +68,7 @@ def raise_arbitrary_error():
 @app.route('/formencoded', methods=['POST'],
            content_types=['application/x-www-form-urlencoded'])
 def form_encoded():
-    parsed = parse_qs(app.current_request.raw_body)
+    parsed = parse_qs(app.current_request.raw_body.decode('utf-8'))
     return {
         'parsed': parsed
     }

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -631,8 +631,8 @@ def test_can_validate_updated_custom_binary_types(sample_app):
     def index():
         return {'hello': 'world'}
 
-    validate_route_content_types(sample_app.routes,
-                                 sample_app.api.binary_types)
+    assert validate_route_content_types(sample_app.routes,
+                                        sample_app.api.binary_types) is None
 
 
 class TestLambdaInitialDeploymentWithConfigurations(object):

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -20,6 +20,7 @@ from chalice.deploy.deployer import LambdaDeployer
 from chalice.deploy.deployer import NoPrompt
 from chalice.deploy.deployer import validate_configuration
 from chalice.deploy.deployer import validate_routes
+from chalice.deploy.deployer import validate_route_content_types
 from chalice.deploy.deployer import validate_python_version
 from chalice.deploy.packager import LambdaDeploymentPackager
 
@@ -609,6 +610,29 @@ def test_cant_have_options_with_cors(sample_app):
 
     with pytest.raises(ValueError):
         validate_routes(sample_app.routes)
+
+
+def test_cant_have_mixed_content_types(sample_app):
+    @sample_app.route('/index', content_types=['application/octet-stream',
+                                               'text/plain'])
+    def index():
+        return {'hello': 'world'}
+
+    with pytest.raises(ValueError):
+        validate_route_content_types(sample_app.routes,
+                                     sample_app.api.binary_types)
+
+
+def test_can_validate_updated_custom_binary_types(sample_app):
+    sample_app.api.binary_types.extend(['text/plain'])
+
+    @sample_app.route('/index', content_types=['application/octet-stream',
+                                               'text/plain'])
+    def index():
+        return {'hello': 'world'}
+
+    validate_route_content_types(sample_app.routes,
+                                 sample_app.api.binary_types)
 
 
 class TestLambdaInitialDeploymentWithConfigurations(object):

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -1,6 +1,6 @@
 from chalice.deploy.swagger import SwaggerGenerator
 from chalice import CORSConfig
-from chalice.app import CustomAuthorizer, CognitoUserPoolAuthorizer, IAMAuthorizer
+from chalice.app import CustomAuthorizer, CognitoUserPoolAuthorizer, IAMAuthorizer, Chalice
 
 import pytest
 from pytest import fixture
@@ -10,6 +10,18 @@ from pytest import fixture
 def swagger_gen():
     return SwaggerGenerator(region='us-west-2',
                             lambda_arn='lambda_arn')
+
+
+def test_can_add_binary_media_types(swagger_gen):
+    app = Chalice('test-binary')
+    doc = swagger_gen.generate_swagger(app)
+    media_types = doc.get('x-amazon-apigateway-binary-media-types')
+    assert sorted(media_types) == sorted([
+        'application/octet-stream',
+        'image/png',
+        'image/jpg',
+        'image/gif'
+    ])
 
 
 def test_can_produce_swagger_top_level_keys(sample_app, swagger_gen):

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -16,23 +16,7 @@ def test_can_add_binary_media_types(swagger_gen):
     app = Chalice('test-binary')
     doc = swagger_gen.generate_swagger(app)
     media_types = doc.get('x-amazon-apigateway-binary-media-types')
-    assert sorted(media_types) == sorted([
-        'application/octet-stream',
-        'application/x-tar',
-        'application/zip',
-        'audio/basic',
-        'audio/ogg',
-        'audio/mp4',
-        'audio/mpeg',
-        'audio/wav',
-        'audio/webm',
-        'image/png',
-        'image/jpg',
-        'image/gif',
-        'video/ogg',
-        'video/mpeg',
-        'video/webm',
-    ])
+    assert sorted(media_types) == sorted(app.api.binary_types)
 
 
 def test_can_produce_swagger_top_level_keys(sample_app, swagger_gen):

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -18,9 +18,20 @@ def test_can_add_binary_media_types(swagger_gen):
     media_types = doc.get('x-amazon-apigateway-binary-media-types')
     assert sorted(media_types) == sorted([
         'application/octet-stream',
+        'application/x-tar',
+        'application/zip',
+        'audio/basic',
+        'audio/ogg',
+        'audio/mp4',
+        'audio/mpeg',
+        'audio/wav',
+        'audio/webm',
         'image/png',
         'image/jpg',
-        'image/gif'
+        'image/gif',
+        'video/ogg',
+        'video/mpeg',
+        'video/webm',
     ])
 
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -31,7 +31,9 @@ def create_event(uri, method, path, content_type='application/json'):
         'stageVariables': {},
     }
 
-def create_empty_header_event(uri, method, path, content_type='application/json'):
+
+def create_empty_header_event(uri, method, path,
+                              content_type='application/json'):
     return {
         'requestContext': {
             'httpMethod': method,
@@ -77,6 +79,26 @@ def sample_app():
     return demo
 
 
+def test_invalid_binary_response_body_throws_value_error(sample_app):
+    response = app.Response(
+        status_code=200,
+        body={'foo': 'bar'},
+        headers={'Content-Type': 'application/octet-stream'}
+    )
+    with pytest.raises(ValueError):
+        response.to_dict(sample_app.api.binary_types)
+
+
+def test_can_encode_binary_body_as_base64(sample_app):
+    response = app.Response(
+        status_code=200,
+        body=b'foobar',
+        headers={'Content-Type': 'application/octet-stream'}
+    )
+    encoded_response = response.to_dict(sample_app.api.binary_types)
+    assert encoded_response['body'] == 'Zm9vYmFy'
+
+
 def test_can_parse_route_view_args():
     entry = app.RouteEntry(lambda: {"foo": "bar"}, 'view-name',
                            '/foo/{bar}/baz/{qux}', methods=['GET'])
@@ -90,9 +112,9 @@ def test_can_route_single_view():
     def index_view():
         return {}
 
-    assert demo.routes['/index'] == app.RouteEntry(index_view, 'index_view',
-                                                   '/index', ['GET'],
-                                                   content_types=['application/json'])
+    assert demo.routes['/index'] == app.RouteEntry(
+        index_view, 'index_view', '/index', ['GET'],
+        content_types=['application/json'])
 
 
 def test_can_handle_multiple_routes():
@@ -176,7 +198,6 @@ def test_can_access_raw_body():
     def index_view():
         return {'rawbody': demo.current_request.raw_body}
 
-
     event = create_event('/index', 'GET', {})
     event['body'] = '{"hello": "world"}'
 
@@ -195,7 +216,6 @@ def test_raw_body_cache_returns_same_result():
         # Both should be the same value
         return {'rawbody': demo.current_request.raw_body,
                 'rawbody2': demo.current_request.raw_body}
-
 
     event = create_event('/index', 'GET', {})
     event['base64-body'] = base64.b64encode(
@@ -225,7 +245,6 @@ def test_json_body_available_with_right_content_type():
     @demo.route('/', methods=['POST'])
     def index():
         return demo.current_request.json_body
-
 
     event = create_event('/', 'POST', {})
     event['body'] = json.dumps({'foo': 'bar'})
@@ -359,6 +378,7 @@ def test_headers_have_basic_validation():
     assert 'Invalid-Header' not in response['headers']
     assert json.loads(response['body'])['Code'] == 'InternalServerError'
 
+
 def test_empty_headers_have_basic_validation():
     demo = app.Chalice('app-name')
 
@@ -370,6 +390,7 @@ def test_empty_headers_have_basic_validation():
     event = create_empty_header_event('/index', 'GET', {})
     response = demo(event, context=None)
     assert response['statusCode'] == 200
+
 
 def test_no_content_type_is_still_allowed():
     # When the content type validation happens in API gateway, it appears
@@ -387,6 +408,24 @@ def test_no_content_type_is_still_allowed():
 
     json_response = json_response_body(demo(event, context=None))
     assert json_response == {'success': True}
+
+
+def test_can_base64_encode_binary_media_types_bytes():
+    demo = app.Chalice('demo-app')
+
+    @demo.route('/index')
+    def index_view():
+        return app.Response(
+            status_code=200,
+            body=b'\u2713',
+            headers={'Content-Type': 'application/octet-stream'})
+
+    event = create_event('/index', 'GET', {})
+    response = demo(event, context=None)
+    assert response['statusCode'] == 200
+    assert response['isBase64Encoded'] is True
+    assert response['body'] == 'XHUyNzEz'
+    assert response['headers']['Content-Type'] == 'application/octet-stream'
 
 
 def test_route_equality():
@@ -545,6 +584,27 @@ def test_json_body_available_when_content_type_matches(content_type, is_json):
         assert request.json_body is None
 
 
+def test_can_receive_binary_data():
+    content_type = 'application/octet-stream'
+    demo = app.Chalice('demo-app')
+
+    @demo.route('/bincat', methods=['POST'], content_types=[content_type])
+    def bincat():
+        raw_body = demo.current_request.raw_body
+        return app.Response(
+            status_code=200,
+            body=raw_body,
+            headers={'Content-Type': content_type})
+
+    body = 'L3UyNzEz'
+    event = create_event_with_body(body, '/bincat', 'POST', content_type)
+    event['isBase64Encoded'] = True
+    response = demo(event, context=None)
+
+    assert response['statusCode'] == 200
+    assert response['body'] == body
+
+
 def test_can_serialize_cognito_auth():
     auth = app.CognitoUserPoolAuthorizer(
         'Name', provider_arns=['Foo'], header='Authorization')
@@ -559,6 +619,7 @@ def test_can_serialize_cognito_auth():
         }
     }
 
+
 def test_can_serialize_iam_auth():
     auth = app.IAMAuthorizer()
     assert auth.to_swagger() == {
@@ -567,6 +628,7 @@ def test_can_serialize_iam_auth():
             'name': 'Authorization',
             'x-amazon-apigateway-authtype': 'awsSigv4',
         }
+
 
 def test_typecheck_list_type():
     with pytest.raises(TypeError):

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -456,6 +456,24 @@ def test_can_base64_encode_binary_media_types_bytes():
     assert response['headers']['Content-Type'] == 'application/octet-stream'
 
 
+def test_can_return_text_even_with_binary_content_type_configured():
+    demo = app.Chalice('demo-app')
+
+    @demo.route('/index')
+    def index_view():
+        return app.Response(
+            status_code=200,
+            body='Plain text',
+            headers={'Content-Type': 'text/plain'})
+
+    event = create_event('/index', 'GET', {})
+    event['headers']['Accept'] = 'application/octet-stream'
+    response = demo(event, context=None)
+    assert response['statusCode'] == 200
+    assert response['body'] == 'Plain text'
+    assert response['headers']['Content-Type'] == 'text/plain'
+
+
 def test_route_equality():
     view_function = lambda: {"hello": "world"}
     a = app.RouteEntry(

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -90,8 +90,7 @@ def test_invalid_binary_response_body_throws_value_error(sample_app):
         headers={'Content-Type': 'application/octet-stream'}
     )
     with pytest.raises(ValueError):
-        app.prepare_response_for_apigateway(response,
-                                            sample_app.api.binary_types)
+        response.to_dict(sample_app.api.binary_types)
 
 
 def test_can_encode_binary_body_as_base64(sample_app):
@@ -100,8 +99,7 @@ def test_can_encode_binary_body_as_base64(sample_app):
         body=b'foobar',
         headers={'Content-Type': 'application/octet-stream'}
     )
-    encoded_response = app.prepare_response_for_apigateway(
-        response, sample_app.api.binary_types)
+    encoded_response = response.to_dict(sample_app.api.binary_types)
     assert encoded_response['body'] == 'Zm9vYmFy'
 
 
@@ -111,8 +109,7 @@ def test_can_encode_binary_body_with_header_charset(sample_app):
         body=b'foobar',
         headers={'Content-Type': 'application/octet-stream; charset=binary'}
     )
-    encoded_response = app.prepare_response_for_apigateway(
-        response, sample_app.api.binary_types)
+    encoded_response = response.to_dict(sample_app.api.binary_types)
     assert encoded_response['body'] == 'Zm9vYmFy'
 
 
@@ -123,8 +120,7 @@ def test_can_encode_binary_json(sample_app):
         body={'foo': 'bar'},
         headers={'Content-Type': 'application/json'}
     )
-    encoded_response = app.prepare_response_for_apigateway(
-        response, sample_app.api.binary_types)
+    encoded_response = response.to_dict(sample_app.api.binary_types)
     assert encoded_response['body'] == 'eyJmb28iOiAiYmFyIn0='
 
 


### PR DESCRIPTION
Payloads with a known binary Content-Type will be automatically
propagated to lambda with app.current_request.raw_body as a bytes-like
object. Responses which have a bytes body and a known binary Content-Type
header will be base64 encoded before being sent to API gateway, and API
gateway will correctly send the data depending on what Accept headers
were present on the request.

Implements #348 


## Example usage
```python
app = Chalice(app_name='test-binary')

@app.route('/binary', methods=['POST'],
           content_types=['application/octet-stream'])
def binary_round_trip():
    return Response(
        app.current_request.raw_body,
        headers={
            'Content-Type': 'application/octet-stream'
        },
        status_code=200)
```

```
$ chalice deploy
.
.
.
$ test-binary echo -n -e '\xDE\xAD\xBE\xEF' | curl -s -H 'Accept: application/octet-stream' -H 'Content-Type: application/octet-stream' -X POST $(chalice url)binary --data-binary @- | xxd
0000000: dead beef                                ....
$ curl -s -H 'Accept: application/octet-stream' -H 'Content-Type: application/octet-stream' -X POST $(chalice url)binary --data-binary @image.png > round_tripped.png
$ diff image.png round_tripped.png
$
```

## Still to do
* Discuss and implement an interface for modifying which types are considered binary, as well as choose a small set of defaults. I picked a small number of defaults for my tests and nothing more.
* Documentation

cc @jamesls @kyleknap 