### PR TITLE
Add vendor/ to the end of sys.path, not beginning

### DIFF
--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -139,7 +139,17 @@ class CLIFactory(object):
         # lambda.
         vendor_dir = os.path.join(self.project_dir, 'vendor')
         if os.path.isdir(vendor_dir) and vendor_dir not in sys.path:
-            sys.path.insert(0, vendor_dir)
+            # This is a tradeoff we have to make for local use.
+            # The common use case of vendor/ is to include
+            # extension modules built for AWS Lambda.  If you're
+            # running on a non-linux dev machine, then attempting
+            # to import these files will raise exceptions.  As
+            # a workaround, the vendor is added to the end of
+            # sys.path so it's after `./lib/site-packages`.
+            # This gives you a change to install the correct
+            # version locally and still keep the lambda
+            # specific one in vendor/
+            sys.path.append(vendor_dir)
         try:
             app = importlib.import_module('app')
             chalice_app = getattr(app, 'app')

--- a/tests/functional/cli/test_factory.py
+++ b/tests/functional/cli/test_factory.py
@@ -101,7 +101,8 @@ def test_filename_and_lineno_included_in_syntax_error(clifactory):
 
 def test_can_import_vendor_package(clifactory):
     # Tests that vendor packages can be imported during config loading.
-    vendedlib_dir = os.path.join(clifactory.project_dir, 'vendor', 'vendedlib')
+    vendor_lib = os.path.join(clifactory.project_dir, 'vendor')
+    vendedlib_dir = os.path.join(vendor_lib, 'vendedlib')
     os.makedirs(vendedlib_dir)
     open(os.path.join(vendedlib_dir, '__init__.py'), 'a').close()
     with open(os.path.join(vendedlib_dir, 'submodule.py'), 'a') as f:
@@ -112,3 +113,4 @@ def test_can_import_vendor_package(clifactory):
         f.write('app.imported_value = submodule.CONST\n')
     app = clifactory.load_chalice_app()
     assert app.imported_value == 'foo bar'
+    assert sys.path[-1] == vendor_lib


### PR DESCRIPTION
This issue here is if I have a binary module built specifically
for Lambda (Amazon Linux) and I try to import that module locally
on a non linux machine (e.g a Mac), I'll get import errors because
I'm trying to import a linux binary on a mac.

As a workaround, the vendor/ directory is added to the end of
sys.path so that site-packages in your venv will take precedence.
This allows you to install the Mac binaries into site-packages
via `pip install` and still have the deployment package correctly
pull in the linux specific extension modules.

cc @kyleknap @stealthycoin 