### PR TITLE
Add upgrade notes for 0.9.0 release

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -366,7 +366,7 @@ class Chalice(object):
         warnings.warn(
             "define_authorizer() is deprecated and will be removed in future "
             "versions of chalice.  Please use CognitoUserPoolAuthorizer(...) "
-            "instead", PendingDeprecationWarning)
+            "instead", DeprecationWarning)
         self._authorizers[name] = {
             'header': header,
             'auth_type': auth_type,

--- a/docs/source/upgrading.rst
+++ b/docs/source/upgrading.rst
@@ -7,6 +7,19 @@ interested in the high level changes, see the
 `CHANGELOG.rst <https://github.com/awslabs/chalice/blob/master/CHANGELOG.rst>`__)
 file.
 
+.. _v0-9-0:
+
+0.9.0
+-----
+
+The 0.9.0 release changed the type of ``app.current_request.raw_body`` to
+always be of type ``bytes()``.  This only affects users that were using
+python3.  Previously you would get a type ``str()``, but with the introduction
+of `binary content type support
+<https://github.com/awslabs/chalice/issues/348>`__, the ``raw_body`` attribute
+was made consistent to always return a type ``bytes()``.
+
+
 .. _v0-8-1:
 
 0.8.1


### PR DESCRIPTION
I also bumped the `PendingDeprecationWarning` to `DeprecationWarning` for the `define_authorizer` function.  Figured I'd save a PR, but I can send another PR if people prefer.

cc @kyleknap @stealthycoin 