### PR TITLE
Update interfaces to multi lambda support

### DIFF
--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -69,6 +69,7 @@ class TypedAWSClient(object):
                         role_arn,                    # type: str
                         zip_contents,                # type: str
                         runtime,                     # type: str
+                        handler,                     # type: str
                         environment_variables=None,  # type: _STR_MAP
                         tags=None,                   # type: _STR_MAP
                         timeout=None,                # type: _OPT_INT
@@ -79,7 +80,7 @@ class TypedAWSClient(object):
             'FunctionName': function_name,
             'Runtime': runtime,
             'Code': {'ZipFile': zip_contents},
-            'Handler': 'app.app',
+            'Handler': handler,
             'Role': role_arn,
         }  # type: Dict[str, Any]
         if environment_variables is not None:

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -352,6 +352,7 @@ class LambdaDeployer(object):
             environment_variables=config.environment_variables,
             runtime=config.lambda_python_version,
             tags=config.tags,
+            handler='app.app',
             timeout=self._get_lambda_timeout(config),
             memory_size=self._get_lambda_memory_size(config)
         )

--- a/chalice/deploy/swagger.py
+++ b/chalice/deploy/swagger.py
@@ -23,10 +23,10 @@ class SwaggerGenerator(object):
         }
     }  # type: Dict[str, Any]
 
-    def __init__(self, region, lambda_arn):
-        # type: (str, str) -> None
+    def __init__(self, region, deployed_resources):
+        # type: (str, Dict[str, Any]) -> None
         self._region = region
-        self._lambda_arn = lambda_arn
+        self._deployed_resources = deployed_resources
 
     def generate_swagger(self, app):
         # type: (Chalice) -> Dict[str, Any]
@@ -147,9 +147,10 @@ class SwaggerGenerator(object):
 
     def _uri(self):
         # type: () -> Any
+        lambda_arn = self._deployed_resources['api_handler_arn']
         return ('arn:aws:apigateway:{region}:lambda:path/2015-03-31'
                 '/functions/{lambda_arn}/invocations').format(
-                    region=self._region, lambda_arn=self._lambda_arn)
+                    region=self._region, lambda_arn=lambda_arn)
 
     def _generate_apig_integ(self, view):
         # type: (RouteEntry) -> Dict[str, Any]

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -26,7 +26,7 @@ def create_app_packager(config):
         # We're add place holder values that will be filled in once the
         # lambda function is deployed.
         SAMTemplateGenerator(
-            CFNSwaggerGenerator('{region}', '{lambda_arn}'),
+            CFNSwaggerGenerator('{region}', {}),
             PreconfiguredPolicyGenerator(
                 config,
                 ApplicationPolicyHandler(

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -296,7 +296,8 @@ class TestCreateLambdaFunction(object):
         stubbed_session.activate_stubs()
         awsclient = TypedAWSClient(stubbed_session)
         assert awsclient.create_function(
-            'name', 'myarn', b'foo', 'python2.7') == 'arn:12345:name'
+            'name', 'myarn', b'foo',
+            'python2.7', 'app.app') == 'arn:12345:name'
         stubbed_session.verify_stubs()
 
     def test_create_function_with_non_python2_runtime(self, stubbed_session):
@@ -310,7 +311,8 @@ class TestCreateLambdaFunction(object):
         stubbed_session.activate_stubs()
         awsclient = TypedAWSClient(stubbed_session)
         assert awsclient.create_function(
-            'name', 'myarn', b'foo', runtime='python3.6') == 'arn:12345:name'
+            'name', 'myarn', b'foo', runtime='python3.6',
+            handler='app.app') == 'arn:12345:name'
         stubbed_session.verify_stubs()
 
     def test_create_function_with_environment_variables(self, stubbed_session):
@@ -326,6 +328,7 @@ class TestCreateLambdaFunction(object):
         awsclient = TypedAWSClient(stubbed_session)
         assert awsclient.create_function(
             'name', 'myarn', b'foo', 'python2.7',
+            handler='app.app',
             environment_variables={'FOO': 'BAR'}) == 'arn:12345:name'
         stubbed_session.verify_stubs()
 
@@ -341,7 +344,7 @@ class TestCreateLambdaFunction(object):
         stubbed_session.activate_stubs()
         awsclient = TypedAWSClient(stubbed_session)
         assert awsclient.create_function(
-            'name', 'myarn', b'foo', 'python2.7',
+            'name', 'myarn', b'foo', 'python2.7', 'app.app',
             timeout=240) == 'arn:12345:name'
         stubbed_session.verify_stubs()
 
@@ -357,7 +360,7 @@ class TestCreateLambdaFunction(object):
         stubbed_session.activate_stubs()
         awsclient = TypedAWSClient(stubbed_session)
         assert awsclient.create_function(
-            'name', 'myarn', b'foo', 'python2.7',
+            'name', 'myarn', b'foo', 'python2.7', 'app.app',
             tags={'mykey': 'myvalue'}) == 'arn:12345:name'
         stubbed_session.verify_stubs()
 
@@ -373,7 +376,7 @@ class TestCreateLambdaFunction(object):
         stubbed_session.activate_stubs()
         awsclient = TypedAWSClient(stubbed_session)
         assert awsclient.create_function(
-            'name', 'myarn', b'foo', 'python2.7',
+            'name', 'myarn', b'foo', 'python2.7', 'app.app',
             memory_size=256) == 'arn:12345:name'
         stubbed_session.verify_stubs()
 
@@ -396,7 +399,7 @@ class TestCreateLambdaFunction(object):
         stubbed_session.activate_stubs()
         awsclient = TypedAWSClient(stubbed_session, mock.Mock(spec=time.sleep))
         assert awsclient.create_function(
-            'name', 'myarn', b'foo', 'python2.7') == 'arn:12345:name'
+            'name', 'myarn', b'foo', 'python2.7', 'app.app') == 'arn:12345:name'
         stubbed_session.verify_stubs()
 
     def test_create_function_fails_after_max_retries(self, stubbed_session):
@@ -415,7 +418,8 @@ class TestCreateLambdaFunction(object):
         stubbed_session.activate_stubs()
         awsclient = TypedAWSClient(stubbed_session, mock.Mock(spec=time.sleep))
         with pytest.raises(botocore.exceptions.ClientError):
-            awsclient.create_function('name', 'myarn', b'foo', 'python2.7')
+            awsclient.create_function('name', 'myarn', b'foo', 'python2.7',
+                                      'app.app')
         stubbed_session.verify_stubs()
 
     def test_can_pass_python_runtime(self, stubbed_session):
@@ -429,7 +433,8 @@ class TestCreateLambdaFunction(object):
         stubbed_session.activate_stubs()
         awsclient = TypedAWSClient(stubbed_session)
         assert awsclient.create_function(
-            'name', 'myarn', b'foo', runtime='python3.6') == 'arn:12345:name'
+            'name', 'myarn', b'foo',
+            runtime='python3.6', handler='app.app') == 'arn:12345:name'
         stubbed_session.verify_stubs()
 
     def test_create_function_propagates_unknown_error(self, stubbed_session):
@@ -446,7 +451,8 @@ class TestCreateLambdaFunction(object):
         stubbed_session.activate_stubs()
         awsclient = TypedAWSClient(stubbed_session, mock.Mock(spec=time.sleep))
         with pytest.raises(botocore.exceptions.ClientError):
-            awsclient.create_function('name', 'myarn', b'foo', 'pytohn2.7')
+            awsclient.create_function('name', 'myarn', b'foo', 'pytohn2.7',
+                                      'app.app')
         stubbed_session.verify_stubs()
 
     def test_can_provide_tags(self, stubbed_session):
@@ -465,7 +471,8 @@ class TestCreateLambdaFunction(object):
             role_arn='myarn',
             zip_contents=b'foo',
             runtime='python2.7',
-            tags={'key': 'value'}) == 'arn:12345:name'
+            tags={'key': 'value'},
+            handler='app.app') == 'arn:12345:name'
         stubbed_session.verify_stubs()
 
 

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -111,7 +111,7 @@ def test_api_gateway_deployer_initial_deploy(config_obj):
     lambda_arn = 'arn:aws:lambda:us-west-2:account-id:function:func-name'
 
     d = APIGatewayDeployer(aws_client)
-    d.deploy(config_obj, None, lambda_arn)
+    d.deploy(config_obj, None, {'api_handler_arn': lambda_arn})
 
     # mock.ANY because we don't want to test the contents of the swagger
     # doc.  That's tested exhaustively elsewhere.
@@ -139,7 +139,7 @@ def test_api_gateway_deployer_redeploy_api(config_obj):
     lambda_arn = 'arn:aws:lambda:us-west-2:account-id:function:func-name'
 
     d = APIGatewayDeployer(aws_client)
-    d.deploy(config_obj, deployed, lambda_arn)
+    d.deploy(config_obj, deployed, {'api_handler_arn': lambda_arn})
 
     aws_client.update_api_from_swagger.assert_called_with('existing-id',
                                                           mock.ANY)
@@ -355,7 +355,14 @@ def test_can_deploy_apig_and_lambda(sample_app):
         project_dir='.')
     d.deploy(cfg)
     lambda_deploy.deploy.assert_called_with(cfg, None, 'dev')
-    apig_deploy.deploy.assert_called_with(cfg, None, 'my_lambda_arn')
+    apig_deploy.deploy.assert_called_with(cfg, None, {
+        'rest_api_id': 'api_id',
+        'chalice_version': chalice_version,
+        'region': 'region',
+        'api_gateway_stage': 'stage',
+        'api_handler_name': 'lambda_function',
+        'api_handler_arn': 'my_lambda_arn', 'backend': 'api'
+    })
 
 
 def test_deployer_returns_deployed_resources(sample_app):

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -599,7 +599,8 @@ def test_lambda_deployer_initial_deploy(app_policy, sample_app):
             'aws-chalice': 'version=%s:stage=dev:app=myapp' % chalice_version,
             'mykey': 'myvalue'
         },
-        timeout=120, memory_size=256
+        handler='app.app',
+        timeout=120, memory_size=256,
     )
 
 
@@ -677,6 +678,7 @@ class TestLambdaInitialDeploymentWithConfigurations(object):
                     chalice_version)
             },
             environment_variables={},
+            handler='app.app',
             timeout=60, memory_size=128
         )
 
@@ -700,6 +702,7 @@ class TestLambdaInitialDeploymentWithConfigurations(object):
                     chalice_version)
             },
             environment_variables={'FOO': 'BAR'},
+            handler='app.app',
             timeout=60, memory_size=128
         )
 
@@ -723,6 +726,7 @@ class TestLambdaInitialDeploymentWithConfigurations(object):
                     chalice_version)
             },
             environment_variables={},
+            handler='app.app',
             timeout=120, memory_size=128
         )
 
@@ -746,6 +750,7 @@ class TestLambdaInitialDeploymentWithConfigurations(object):
                     chalice_version)
             },
             environment_variables={},
+            handler='app.app',
             timeout=60, memory_size=256
         )
 
@@ -770,6 +775,7 @@ class TestLambdaInitialDeploymentWithConfigurations(object):
                 'mykey': 'myvalue'
             },
             environment_variables={},
+            handler='app.app',
             timeout=60, memory_size=128
         )
 

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -8,8 +8,9 @@ from pytest import fixture
 
 @fixture
 def swagger_gen():
-    return SwaggerGenerator(region='us-west-2',
-                            lambda_arn='lambda_arn')
+    return SwaggerGenerator(
+        region='us-west-2',
+        deployed_resources={'api_handler_arn': 'lambda_arn'})
 
 
 def test_can_add_binary_media_types(swagger_gen):


### PR DESCRIPTION
* Don't hard code the lambda handler string
* Replace anything that accepted a single lambda arn with a `deployed_resources` dict.

This updates the cases where the deployer accepts a single lambda
ARN.  This is going to have with multi lambda function, so this plumbs
through the change to instead accept a dict.  This gives some
flexibility because we change the dict keys if needed without having
to update all these interfaces again.

Should make rebasing/shared branches easier.

No function changes.