### PR TITLE
Prevent creation of invalid pipeline templates.

### DIFF
--- a/chalice/pipeline.py
+++ b/chalice/pipeline.py
@@ -36,7 +36,7 @@ class CreatePipelineTemplate(object):
                 "Description": "Enter the name of your application"
             },
             "CodeBuildImage": {
-                "Default": "python:2.7.12",
+                "Default": "aws/codebuild/python:2.7.12",
                 "Type": "String",
                 "Description": "Name of codebuild image to use."
             }
@@ -52,8 +52,8 @@ class CreatePipelineTemplate(object):
     def _codebuild_image(self, lambda_python_version):
         # type: (str) -> str
         try:
-            image = self._CODEBUILD_IMAGE[lambda_python_version]
-            return image
+            image_suffix = self._CODEBUILD_IMAGE[lambda_python_version]
+            return 'aws/codebuild/%s' % image_suffix
         except KeyError as e:
             raise InvalidCodeBuildPythonVersion(str(e))
 
@@ -121,9 +121,7 @@ class CodeBuild(BaseResource):
                 "Environment": {
                     "ComputeType": "BUILD_GENERAL1_SMALL",
                     "Image": {
-                        "Fn::Join": [
-                            "", ["aws/codebuild/", {"Ref": "PythonVersion"}]
-                        ]
+                        "Ref": "CodeBuildImage"
                     },
                     "Type": "LINUX_CONTAINER",
                     "EnvironmentVariables": [

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -1,6 +1,7 @@
 import json
 import zipfile
 import os
+import sys
 
 import pytest
 from click.testing import CliRunner
@@ -292,6 +293,10 @@ def test_error_when_no_deployed_record(runner, mock_cli_factory):
         assert 'not find' in result.output
 
 
+@pytest.mark.skipif(sys.version_info[0] == 3,
+                    reason=('Python Version 3 cannot create pipelines due to '
+                            'CodeBuild not having a Python 3.6 image. This '
+                            'mark can be removed when that image exists.'))
 def test_can_generate_pipeline_for_all(runner):
     with runner.isolated_filesystem():
         cli.create_new_project_skeleton('testproject')

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -17,7 +17,7 @@ def test_app_name_in_param_default(pipeline_gen):
 def test_python_version_in_param_default(pipeline_gen):
     template = pipeline_gen.create_template('app', 'python2.7')
     assert template['Parameters']['CodeBuildImage']['Default'] == \
-        'python:2.7.12'
+        'aws/codebuild/python:2.7.12'
 
 
 def test_py3_throws_error(pipeline_gen):

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -1,6 +1,7 @@
 import pytest
 
 from chalice import pipeline
+from chalice.pipeline import InvalidCodeBuildPythonVersion
 
 
 @pytest.fixture
@@ -9,8 +10,25 @@ def pipeline_gen():
 
 
 def test_app_name_in_param_default(pipeline_gen):
-    template = pipeline_gen.create_template('appname')
+    template = pipeline_gen.create_template('appname', 'python2.7')
     assert template['Parameters']['ApplicationName']['Default'] == 'appname'
+
+
+def test_python_version_in_param_default(pipeline_gen):
+    template = pipeline_gen.create_template('app', 'python2.7')
+    assert template['Parameters']['CodeBuildImage']['Default'] == \
+        'python:2.7.12'
+
+
+def test_py3_throws_error(pipeline_gen):
+    # This test can be removed when there is a 3.6 codebuild image available
+    with pytest.raises(InvalidCodeBuildPythonVersion):
+        pipeline_gen.create_template('app', 'python3.6')
+
+
+def test_nonsense_py_version_throws_error(pipeline_gen):
+    with pytest.raises(InvalidCodeBuildPythonVersion):
+        pipeline_gen.create_template('app', 'foobar')
 
 
 def test_source_repo_resource(pipeline_gen):


### PR DESCRIPTION
Currently CodeBuild does not support python 3.6, Chalice projects
that use generate-pipeline will create a pipeline that will result in a
python 2.7 lambda function. Until support is added in CodeBuild trying
to create a template in Chalice should result in an error.

cc @jamesls @kyleknap 