### PR TITLE
Allow view functions to share route url and differ in HTTP method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,9 @@ Next Release (TBD)
   (`#339 <https://github.com/awslabs/chalice/issues/339>`__)
 * Fix ``autogen_policy`` in config being ignored
   (`#367 <https://github.com/awslabs/chalice/pull/367>`__)
+* Add support for view functions that share the same view url but
+  differ by HTTP method
+  (`#81 <https://github.com/awslabs/chalice/issues/81>`__)
 
 
 0.9.0

--- a/README.rst
+++ b/README.rst
@@ -426,9 +426,30 @@ specified resource.  For example:
         pass
 
 The above view function will be called when either an HTTP POST or
-PUT is sent to ``/myview``.  In the next section we'll go over
-how you can introspect the given request in order to differentiate between
-various HTTP methods.
+PUT is sent to ``/myview``.
+
+Alternatively if you do not want to share the same view function across
+multiple HTTP methods for the same route url, you may define separate view
+functions to the same route url but have the view functions differ by
+HTTP method. For example:
+
+.. code-block:: python
+
+    @app.route('/myview', methods=['POST'])
+    def myview_post():
+        pass
+
+    @app.route('/myview', methods=['PUT'])
+    def myview_put():
+        pass
+
+This setup will route all HTTP POST's to ``/myview`` to the ``myview_post()``
+view function and route all HTTP PUT's to ``/myview`` to the ``myview_put()``
+view function.
+
+In the next section we'll go over how you can introspect the given request
+in order to differentiate between various HTTP methods.
+
 
 Tutorial: Request Metadata
 ==========================

--- a/README.rst
+++ b/README.rst
@@ -445,7 +445,9 @@ HTTP method. For example:
 
 This setup will route all HTTP POST's to ``/myview`` to the ``myview_post()``
 view function and route all HTTP PUT's to ``/myview`` to the ``myview_put()``
-view function.
+view function. It is also important to note that the view functions
+**must** have unique names. For example, both view functions cannot be
+named ``myview()``.
 
 In the next section we'll go over how you can introspect the given request
 in order to differentiate between various HTTP methods.

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -486,8 +486,12 @@ class Chalice(object):
             if method in self.routes[path]:
                 raise ValueError(
                     "Duplicate method: '%s' detected for route: '%s'\n"
-                    "A specific method may only be specified once for "
-                    "a particular path." % (method, path))
+                    "between view functions: \"%s\" and \"%s\". A specific "
+                    "method may only be specified once for "
+                    "a particular path." % (
+                        method, path, self.routes[path][method].view_name,
+                        name)
+                )
             entry = RouteEntry(view_func, name, path, method,
                                authorizer_name, api_key_required,
                                content_types, cors, authorizer)

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -7,7 +7,7 @@ import traceback
 import decimal
 import warnings
 import base64
-from collections import Mapping
+from collections import defaultdict, Mapping
 
 # Implementation note:  This file is intended to be a standalone file
 # that gets copied into the lambda deployment package.  It has no dependencies
@@ -232,6 +232,11 @@ class CORSConfig(object):
 
         return headers
 
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.get_access_control_headers() == \
+                other.get_access_control_headers()
+
 
 class Request(object):
     """The current request from API gateway."""
@@ -333,14 +338,14 @@ class Response(object):
 
 class RouteEntry(object):
 
-    def __init__(self, view_function, view_name, path, methods,
+    def __init__(self, view_function, view_name, path, method,
                  authorizer_name=None,
                  api_key_required=None, content_types=None,
                  cors=False, authorizer=None):
         self.view_function = view_function
         self.view_name = view_name
         self.uri_pattern = path
-        self.methods = methods
+        self.method = method
         self.authorizer_name = authorizer_name
         self.api_key_required = api_key_required
         #: A list of names to extract from path:
@@ -406,7 +411,7 @@ class Chalice(object):
     def __init__(self, app_name, configure_logs=True):
         self.app_name = app_name
         self.api = APIGateway()
-        self.routes = {}
+        self.routes = defaultdict(dict)
         self.current_request = None
         self.debug = False
         self.configure_logs = configure_logs
@@ -477,14 +482,16 @@ class Chalice(object):
         if kwargs:
             raise TypeError('TypeError: route() got unexpected keyword '
                             'arguments: %s' % ', '.join(list(kwargs)))
-        if path in self.routes:
-            raise ValueError(
-                "Duplicate route detected: '%s'\n"
-                "URL paths must be unique." % path)
-        entry = RouteEntry(view_func, name, path, methods,
-                           authorizer_name, api_key_required,
-                           content_types, cors, authorizer)
-        self.routes[path] = entry
+        for method in methods:
+            if method in self.routes[path]:
+                raise ValueError(
+                    "Duplicate method: '%s' detected for route: '%s'\n"
+                    "A specific method may only be specified once for "
+                    "a particular path." % (method, path))
+            entry = RouteEntry(view_func, name, path, method,
+                               authorizer_name, api_key_required,
+                               content_types, cors, authorizer)
+            self.routes[path][method] = entry
 
     def __call__(self, event, context):
         # This is what's invoked via lambda.
@@ -499,12 +506,12 @@ class Chalice(object):
         http_method = event['requestContext']['httpMethod']
         if resource_path not in self.routes:
             raise ChaliceError("No view function for: %s" % resource_path)
-        route_entry = self.routes[resource_path]
-        if http_method not in route_entry.methods:
+        if http_method not in self.routes[resource_path]:
             return error_response(
                 error_code='MethodNotAllowedError',
                 message='Unsupported method: %s' % http_method,
                 http_status_code=405)
+        route_entry = self.routes[resource_path][http_method]
         view_function = route_entry.view_function
         function_args = [event['pathParameters'][name]
                          for name in route_entry.view_args]

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -32,6 +32,8 @@ class CORSConfig:
     allow_headers = ... # type: str
     get_access_control_headers = ... # type: Callable[..., Dict[str, str]]
 
+    def __eq__(self, other: object) -> bool: ...
+
 
 class Request:
     query_params = ... # type: Dict[str, str]
@@ -73,7 +75,7 @@ class RouteEntry(object):
     # TODO: How so I specify *args, where args is a tuple of strings.
     view_function = ... # type: Callable[..., Any]
     view_name = ... # type: str
-    methods = ... # type: List[str]
+    method = ... # type: str
     uri_pattern = ... # type: str
     authorizer_name = ... # type: str
     authorizer = ... # type: Optional[Authorizer]
@@ -101,7 +103,7 @@ class APIGateway(object):
 class Chalice(object):
     app_name = ... # type: str
     api = ... # type: APIGateway
-    routes = ... # type: Dict[str, RouteEntry]
+    routes = ... # type: Dict[str, Dict[str, RouteEntry]]
     current_request = ... # type: Request
     debug = ... # type: bool
     authorizers = ... # type: Dict[str, Dict[str, Any]]

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -130,7 +130,7 @@ def _validate_entry_content_type(route_entry, binary_types):
 def _validate_cors_for_route(route_url, route_methods):
     # type: (str, Dict[str, app.RouteEntry]) -> None
     entries_with_cors = [
-        entry for _, entry in route_methods.items() if entry.cors
+        entry for entry in route_methods.values() if entry.cors
     ]
     if entries_with_cors:
         # If the user has enabled CORS, they can't also have an OPTIONS
@@ -147,7 +147,7 @@ def _validate_cors_for_route(route_url, route_methods):
         if not all(entries_with_cors[0].cors == entry.cors for entry in
                    entries_with_cors):
             raise ValueError(
-                "Route may not have mulitple differing CORS configurations. "
+                "Route may not have multiple differing CORS configurations. "
                 "Please ensure all views for \"%s\" that have CORS configured "
                 "have the same CORS configuration." % route_url
             )

--- a/chalice/local.py
+++ b/chalice/local.py
@@ -189,17 +189,10 @@ class ChaliceRequestHandler(BaseHTTPRequestHandler):
             # generate.
             self._send_autogen_options_response()
 
-    def _cors_enabled_for_route(self, lambda_event):
-        # type: (EventType) -> CORSConfig
-        route_key = lambda_event['requestContext']['resourcePath']
-        route_entry = self.app_object.routes[route_key]
-        return route_entry.cors
-
     def _has_user_defined_options_method(self, lambda_event):
         # type: (EventType) -> bool
         route_key = lambda_event['requestContext']['resourcePath']
-        route_entry = self.app_object.routes[route_key]
-        return 'OPTIONS' in route_entry.methods
+        return 'OPTIONS' in self.app_object.routes[route_key]
 
     def _send_autogen_options_response(self):
         # type:() -> None

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -128,8 +128,8 @@ class SAMTemplateGenerator(object):
     def _generate_function_events(self, app):
         # type: (Chalice) -> Dict[str, Any]
         events = {}
-        for _, view in app.routes.items():
-            for http_method in view.methods:
+        for methods in app.routes.values():
+            for http_method, view in methods.items():
                 key_name = ''.join([
                     view.view_name, http_method.lower(),
                     hashlib.md5(

--- a/docs/source/topics/views.rst
+++ b/docs/source/topics/views.rst
@@ -136,6 +136,86 @@ for errors.  For example:
                         status_code=400)
 
 
+
+Specifying HTTP Methods
+-----------------------
+
+So far, our examples have only allowed GET requests. It's actually possible
+to support additional HTTP methods. Here's an example of a view function that
+supports PUT:
+
+.. code-block:: python
+
+    @app.route('/resource/{value}', methods=['PUT'])
+    def put_test(value):
+        return {"value": value}
+
+We can test this method using the ``http`` command::
+
+    $ http PUT https://endpoint/dev/resource/foo
+    HTTP/1.1 200 OK
+
+    {
+        "value": "foo"
+    }
+
+Note that the ``methods`` kwarg accepts a list of methods.  Your view function
+will be called when any of the HTTP methods you specify are used for the
+specified resource.  For example:
+
+.. code-block:: python
+
+    @app.route('/myview', methods=['POST', 'PUT'])
+    def myview():
+        pass
+
+The above view function will be called when either an HTTP POST or
+PUT is sent to ``/myview`` as shown below::
+
+    POST /myview   --> myview()
+    PUT /myview  --> myview()
+
+Alternatively if you do not want to share the same view function across
+multiple HTTP methods for the same route url, you may define separate view
+functions to the same route url but have the view functions differ by
+HTTP method. For example:
+
+.. code-block:: python
+
+    @app.route('/myview', methods=['POST'])
+    def myview_post():
+        pass
+
+    @app.route('/myview', methods=['PUT'])
+    def myview_put():
+        pass
+
+This setup will route all HTTP POST's to ``/myview`` to the ``myview_post()``
+view function and route all HTTP PUT's to ``/myview`` to the ``myview_put()``
+view function as shown below::
+
+    POST /myview   --> myview_post()
+    PUT /myview  --> myview_put()
+
+If you do chose to use separate view functions for the same route path, it is
+important to know:
+
+* View functions that share the same route cannot have the same names.
+  For example, two view functions that both share the same route path cannot
+  both be named ``view()``.
+
+* View functions that share the same route cannot overlap in supported HTTP
+  methods. For example if two view function both share the same route path,
+  they both cannot contain ``'PUT'`` in their route ``methods`` list.
+
+* View functions that share the same route path and have CORS configured cannot
+  have differing CORS configuration. For example, if two view functions that
+  both share the same route path, the route configuration for one of the
+  view functions cannot set ``cors=True`` while having the route
+  configuration of the other view function be set to
+  ``cors=app.CORSConfig(allow_origin='https://foo.example.com')``.
+
+
 Binary Content
 --------------
 

--- a/tests/integration/test_features.py
+++ b/tests/integration/test_features.py
@@ -168,6 +168,14 @@ def test_supports_put(smoke_test_app):
         response.raise_for_status()
 
 
+def test_supports_shared_routes(smoke_test_app):
+    app_url = smoke_test_app.url
+    response = requests.get(app_url + '/shared')
+    assert response.json() == {'method': 'GET'}
+    response = requests.post(app_url + '/shared')
+    assert response.json() == {'method': 'POST'}
+
+
 def test_can_read_json_body_on_post(smoke_test_app):
     app_url = smoke_test_app.url
     response = requests.post(

--- a/tests/integration/testapp/app.py
+++ b/tests/integration/testapp/app.py
@@ -138,3 +138,13 @@ def custom_binary_round_trip():
             'Content-Type': 'application/binary'
         },
         status_code=200)
+
+
+@app.route('/shared', methods=['GET'])
+def shared_get():
+    return {'method': 'GET'}
+
+
+@app.route('/shared', methods=['POST'])
+def shared_post():
+    return {'method': 'POST'}

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -9,6 +9,7 @@ from pytest import fixture
 
 from chalice import __version__ as chalice_version
 from chalice.app import Chalice
+from chalice.app import CORSConfig
 from chalice.awsclient import TypedAWSClient
 from chalice.awsclient import ResourceDoesNotExistError
 from chalice.config import Config, DeployedResources
@@ -611,14 +612,70 @@ def test_lambda_deployer_initial_deploy(app_policy, sample_app):
         timeout=120, memory_size=256,
     )
 
+class TestValidateCORS(object):
+    def test_cant_have_options_with_cors(self, sample_app):
+        @sample_app.route('/badcors', methods=['GET', 'OPTIONS'], cors=True)
+        def badview():
+            pass
 
-def test_cant_have_options_with_cors(sample_app):
-    @sample_app.route('/badcors', methods=['GET', 'OPTIONS'], cors=True)
-    def badview():
-        pass
+        with pytest.raises(ValueError):
+            validate_routes(sample_app.routes)
 
-    with pytest.raises(ValueError):
-        validate_routes(sample_app.routes)
+    def test_cant_have_differing_cors_configurations(self, sample_app):
+        custom_cors = CORSConfig(
+            allow_origin='https://foo.example.com',
+            allow_headers=['X-Special-Header'],
+            max_age=600,
+            expose_headers=['X-Special-Header'],
+            allow_credentials=True
+        )
+
+        @sample_app.route('/cors', methods=['GET'], cors=True)
+        def cors():
+            pass
+
+        @sample_app.route('/cors', methods=['PUT'], cors=custom_cors)
+        def different_cors():
+            pass
+
+        with pytest.raises(ValueError):
+            validate_routes(sample_app.routes)
+
+    def test_can_have_same_cors_configurations(self, sample_app):
+        @sample_app.route('/cors', methods=['GET'], cors=True)
+        def cors():
+            pass
+
+        @sample_app.route('/cors', methods=['PUT'], cors=True)
+        def same_cors():
+            pass
+
+        try:
+            validate_routes(sample_app.routes)
+        except ValueError:
+            pytest.fail(
+                'A ValueError was unexpectedly thrown. Applications '
+                'may have multiple view functions that share the same '
+                'route and CORS configuration.'
+            )
+
+    def test_can_have_one_cors_configured_and_others_not(self, sample_app):
+        @sample_app.route('/cors', methods=['GET'], cors=True)
+        def cors():
+            pass
+
+        @sample_app.route('/cors', methods=['PUT'])
+        def no_cors():
+            pass
+
+        try:
+            validate_routes(sample_app.routes)
+        except ValueError:
+            pytest.fail(
+                'A ValueError was unexpectedly thrown. Applications '
+                'may have multiple view functions that share the same '
+                'route but only one is configured for CORS.'
+            )
 
 
 def test_cant_have_mixed_content_types(sample_app):

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -659,6 +659,38 @@ class TestValidateCORS(object):
                 'route and CORS configuration.'
             )
 
+    def test_can_have_same_custom_cors_configurations(self, sample_app):
+        custom_cors = CORSConfig(
+            allow_origin='https://foo.example.com',
+            allow_headers=['X-Special-Header'],
+            max_age=600,
+            expose_headers=['X-Special-Header'],
+            allow_credentials=True
+        )
+        @sample_app.route('/cors', methods=['GET'], cors=custom_cors)
+        def cors():
+            pass
+
+        same_custom_cors = CORSConfig(
+            allow_origin='https://foo.example.com',
+            allow_headers=['X-Special-Header'],
+            max_age=600,
+            expose_headers=['X-Special-Header'],
+            allow_credentials=True
+        )
+        @sample_app.route('/cors', methods=['PUT'], cors=same_custom_cors)
+        def same_cors():
+            pass
+
+        try:
+            validate_routes(sample_app.routes)
+        except ValueError:
+            pytest.fail(
+                'A ValueError was unexpectedly thrown. Applications '
+                'may have multiple view functions that share the same '
+                'route and CORS configuration.'
+            )
+
     def test_can_have_one_cors_configured_and_others_not(self, sample_app):
         @sample_app.route('/cors', methods=['GET'], cors=True)
         def cors():

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -756,3 +756,20 @@ class TestCORSConfig(object):
         differing_cors_config = app.CORSConfig(
             allow_origin='https://foo.example.com')
         assert cors_config != differing_cors_config
+
+    def test_eq_non_default_configurations(self):
+        custom_cors = app.CORSConfig(
+            allow_origin='https://foo.example.com',
+            allow_headers=['X-Special-Header'],
+            max_age=600,
+            expose_headers=['X-Special-Header'],
+            allow_credentials=True
+        )
+        same_custom_cors = app.CORSConfig(
+            allow_origin='https://foo.example.com',
+            allow_headers=['X-Special-Header'],
+            max_age=600,
+            expose_headers=['X-Special-Header'],
+            allow_credentials=True
+        )
+        assert custom_cors == same_custom_cors

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -126,7 +126,7 @@ def test_can_encode_binary_json(sample_app):
 
 def test_can_parse_route_view_args():
     entry = app.RouteEntry(lambda: {"foo": "bar"}, 'view-name',
-                           '/foo/{bar}/baz/{qux}', methods=['GET'])
+                           '/foo/{bar}/baz/{qux}', method='GET')
     assert entry.view_args == ['bar', 'qux']
 
 
@@ -137,8 +137,8 @@ def test_can_route_single_view():
     def index_view():
         return {}
 
-    assert demo.routes['/index'] == app.RouteEntry(
-        index_view, 'index_view', '/index', ['GET'],
+    assert demo.routes['/index']['GET'] == app.RouteEntry(
+        index_view, 'index_view', '/index', 'GET',
         content_types=['application/json'])
 
 
@@ -156,8 +156,8 @@ def test_can_handle_multiple_routes():
     assert len(demo.routes) == 2, demo.routes
     assert '/index' in demo.routes, demo.routes
     assert '/other' in demo.routes, demo.routes
-    assert demo.routes['/index'].view_function == index_view
-    assert demo.routes['/other'].view_function == other_view
+    assert demo.routes['/index']['GET'].view_function == index_view
+    assert demo.routes['/other']['GET'].view_function == other_view
 
 
 def test_error_on_unknown_event(sample_app):
@@ -250,7 +250,30 @@ def test_raw_body_cache_returns_same_result():
     assert result['rawbody'] == result['rawbody2']
 
 
-def test_error_on_duplicate_routes():
+def test_can_have_views_of_same_route_but_different_methods():
+    demo = app.Chalice('app-name')
+
+    @demo.route('/index', methods=['GET'])
+    def get_view():
+        return {'method': 'GET'}
+
+    @demo.route('/index', methods=['PUT'])
+    def put_view():
+        return {'method': 'PUT'}
+
+    assert demo.routes['/index']['GET'].view_function == get_view
+    assert demo.routes['/index']['PUT'].view_function == put_view
+
+    event = create_event('/index', 'GET', {})
+    result = demo(event, context=None)
+    assert json_response_body(result) == {'method': 'GET'}
+
+    event = create_event('/index', 'PUT', {})
+    result = demo(event, context=None)
+    assert json_response_body(result) == {'method': 'PUT'}
+
+
+def test_error_on_duplicate_route_methods():
     demo = app.Chalice('app-name')
 
     @demo.route('/index', methods=['PUT'])
@@ -258,8 +281,8 @@ def test_error_on_duplicate_routes():
         return {'foo': 'bar'}
 
     with pytest.raises(ValueError):
-        @demo.route('/index', methods=['POST'])
-        def index_post():
+        @demo.route('/index', methods=['PUT'])
+        def index_view_dup():
             return {'foo': 'bar'}
 
 
@@ -479,14 +502,14 @@ def test_route_equality():
     a = app.RouteEntry(
         view_function,
         view_name='myview', path='/',
-        methods=['GET'],
+        method='GET',
         api_key_required=True,
         content_types=['application/json'],
     )
     b = app.RouteEntry(
         view_function,
         view_name='myview', path='/',
-        methods=['GET'],
+        method='GET',
         api_key_required=True,
         content_types=['application/json'],
     )
@@ -498,14 +521,14 @@ def test_route_inequality():
     a = app.RouteEntry(
         view_function,
         view_name='myview', path='/',
-        methods=['GET'],
+        method='GET',
         api_key_required=True,
         content_types=['application/json'],
     )
     b = app.RouteEntry(
         view_function,
         view_name='myview', path='/',
-        methods=['GET'],
+        method='GET',
         api_key_required=True,
         # Different content types
         content_types=['application/xml'],
@@ -715,3 +738,21 @@ def test_can_serialize_custom_authorizer():
             'authorizerResultTtlInSeconds': 10,
         }
     }
+
+
+class TestCORSConfig(object):
+    def test_eq(self):
+        cors_config = app.CORSConfig()
+        other_cors_config = app.CORSConfig()
+        assert cors_config == other_cors_config
+
+    def test_not_eq_different_type(self):
+        cors_config = app.CORSConfig()
+        different_type_obj = object()
+        assert cors_config != different_type_obj
+
+    def test_not_eq_differing_configurations(self):
+        cors_config = app.CORSConfig()
+        differing_cors_config = app.CORSConfig(
+            allow_origin='https://foo.example.com')
+        assert cors_config != differing_cors_config


### PR DESCRIPTION
This adds support for defining multiple view functions that share the same route path but only differ by HTTP method. Also added support for comparing CORSConfig objects for equality.

Implements https://github.com/awslabs/chalice/issues/81

cc @jamesls @stealthycoin 