### PR TITLE
Added packaging support for whl files.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Next Release (TBD)
   (`#390 <https://github.com/awslabs/chalice/issues/390>`__)
 * Add support for pure lambda functions
   (`#390 <https://github.com/awslabs/chalice/issues/400>`__)
+* Add support for wheel packaging.
+  (`#249 <https://github.com/awslabs/chalice/issues/249>`__)
 
 
 0.10.1

--- a/chalice/compat.py
+++ b/chalice/compat.py
@@ -1,17 +1,19 @@
-import os
-import platform
 import socket
 import six
+
+from six import StringIO
 
 
 if six.PY3:
     from urllib.parse import urlparse, parse_qs
+    lambda_abi = 'cp36m'
 
     def is_broken_pipe_error(error):
         # type: (Exception) -> bool
         return isinstance(error, BrokenPipeError)  # noqa
 else:
     from urlparse import urlparse, parse_qs
+    lambda_abi = 'cp27mu'
 
     def is_broken_pipe_error(error):
         # type: (Exception) -> bool
@@ -21,29 +23,3 @@ else:
         # don't want to be assuming all socket.error are broken pipes so just
         # check if the message has 'Broken pipe' in it.
         return isinstance(error, socket.error) and 'Broken pipe' in str(error)
-
-
-if platform.system() == 'Windows':
-    def pip_script_in_venv(venv_dir):
-        # type: (str) -> str
-        pip_exe = os.path.join(venv_dir, 'Scripts', 'pip.exe')
-        return pip_exe
-
-    def site_packages_dir_in_venv(venv_dir):
-        # type: (str) -> str
-        deps_dir = os.path.join(venv_dir, 'Lib', 'site-packages')
-        return deps_dir
-
-else:
-    # Posix platforms.
-
-    def pip_script_in_venv(venv_dir):
-        # type: (str) -> str
-        pip_exe = os.path.join(venv_dir, 'bin', 'pip')
-        return pip_exe
-
-    def site_packages_dir_in_venv(venv_dir):
-        # type: (str) -> str
-        python_dir = os.listdir(os.path.join(venv_dir, 'lib'))[0]
-        deps_dir = os.path.join(venv_dir, 'lib', python_dir, 'site-packages')
-        return deps_dir

--- a/chalice/constants.py
+++ b/chalice/constants.py
@@ -197,3 +197,15 @@ If you'd like to proceded, then answer the questions
 below.
 
 Please enter the project name"""
+
+
+MISSING_DEPENDENCIES_TEMPLATE = r"""
+Could not install dependencies:
+%s
+You will have to build these yourself and vendor them in
+the chalice vendor folder.
+
+Your deployment will continue but may not work correctly
+if missing dependencies are not present. For more information:
+http://chalice.readthedocs.io/en/latest/topics/packaging.html
+"""

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -689,6 +689,18 @@ class LambdaDeployer(object):
             return DEFAULT_LAMBDA_MEMORY_SIZE
         return config.lambda_memory_size
 
+    def _can_reuse_deployment_package(self, config, lambda_name,
+                                      deployment_package_filename):
+        # type: (Config, str, str) -> bool
+        if not self._osutils.file_exists(deployment_package_filename):
+            return False
+        lambda_config = self._aws_client.get_function_configuration(
+            lambda_name)
+        lambda_python_version = config.lambda_python_version
+        if lambda_config['Runtime'] != lambda_python_version:
+            return False
+        return True
+
     def _update_lambda_function(self, config, lambda_name, stage_name):
         # type: (Config, str, str) -> Dict[str, Any]
         print("Updating lambda function...")
@@ -696,9 +708,10 @@ class LambdaDeployer(object):
         packager = self._packager
         deployment_package_filename = packager.deployment_package_filename(
             project_dir)
-        if self._osutils.file_exists(deployment_package_filename):
-            packager.inject_latest_app(deployment_package_filename,
-                                       project_dir)
+        if self._can_reuse_deployment_package(config, lambda_name,
+                                              deployment_package_filename):
+            packager.inject_latest_app(
+                deployment_package_filename, project_dir)
         else:
             deployment_package_filename = packager.create_deployment_package(
                 project_dir)

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -54,8 +54,8 @@ def create_default_deployer(session, prompter=None):
     aws_client = TypedAWSClient(session)
     api_gateway_deploy = APIGatewayDeployer(aws_client)
 
-    packager = LambdaDeploymentPackager()
     osutils = OSUtils()
+    packager = LambdaDeploymentPackager(osutils=osutils)
     lambda_deploy = LambdaDeployer(
         aws_client, packager, prompter, osutils,
         ApplicationPolicyHandler(
@@ -565,7 +565,8 @@ class LambdaDeployer(object):
         role_arn = self._get_or_create_lambda_role_arn(
             config, api_handler_name)
         zip_contents = self._osutils.get_file_contents(
-            self._packager.deployment_package_filename(config.project_dir),
+            self._packager.deployment_package_filename(
+                config.project_dir, config.lambda_python_version),
             binary=True)
         function_name = api_handler_name + '-' + name
         if self._aws_client.lambda_function_exists(function_name):
@@ -661,7 +662,7 @@ class LambdaDeployer(object):
         print("Initial creation of lambda function.")
         role_arn = self._get_or_create_lambda_role_arn(config, function_name)
         zip_filename = self._packager.create_deployment_package(
-            config.project_dir)
+            config.project_dir, config.lambda_python_version)
         zip_contents = self._osutils.get_file_contents(
             zip_filename, binary=True)
 
@@ -689,32 +690,19 @@ class LambdaDeployer(object):
             return DEFAULT_LAMBDA_MEMORY_SIZE
         return config.lambda_memory_size
 
-    def _can_reuse_deployment_package(self, config, lambda_name,
-                                      deployment_package_filename):
-        # type: (Config, str, str) -> bool
-        if not self._osutils.file_exists(deployment_package_filename):
-            return False
-        lambda_config = self._aws_client.get_function_configuration(
-            lambda_name)
-        lambda_python_version = config.lambda_python_version
-        if lambda_config['Runtime'] != lambda_python_version:
-            return False
-        return True
-
     def _update_lambda_function(self, config, lambda_name, stage_name):
         # type: (Config, str, str) -> Dict[str, Any]
         print("Updating lambda function...")
         project_dir = config.project_dir
         packager = self._packager
         deployment_package_filename = packager.deployment_package_filename(
-            project_dir)
-        if self._can_reuse_deployment_package(config, lambda_name,
-                                              deployment_package_filename):
+            project_dir, config.lambda_python_version)
+        if self._osutils.file_exists(deployment_package_filename):
             packager.inject_latest_app(
                 deployment_package_filename, project_dir)
         else:
             deployment_package_filename = packager.create_deployment_package(
-                project_dir)
+                project_dir, config.lambda_python_version)
         zip_contents = self._osutils.get_file_contents(
             deployment_package_filename, binary=True)
         role_arn = self._get_or_create_lambda_role_arn(config, lambda_name)

--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -1,87 +1,94 @@
 from __future__ import print_function
+import sys
 import hashlib
 import inspect
 import os
+import re
 import shutil
-import subprocess
 import zipfile
+import tarfile
+import subprocess
+from email.parser import FeedParser
+from email.message import Message  # noqa
 
-import virtualenv
-from typing import Any, Optional  # noqa
+from typing import Any, Set, List, Optional, Tuple, Iterable, Callable  # noqa
+from chalice.compat import lambda_abi
+from chalice.utils import OSUtils
+from chalice.constants import MISSING_DEPENDENCIES_TEMPLATE
 
 import chalice
-from chalice import compat, app
+from chalice import app
+
+
+class InvalidSourceDistributionNameError(Exception):
+    pass
+
+
+class MissingDependencyError(Exception):
+    def __init__(self, missing):
+        # type: (Set[Package]) -> None
+        self.missing = missing
+
+
+class PipError(Exception):
+    pass
 
 
 class LambdaDeploymentPackager(object):
     _CHALICE_LIB_DIR = 'chalicelib'
     _VENDOR_DIR = 'vendor'
 
-    def _create_virtualenv(self, venv_dir):
-        # type: (str) -> None
-        virtualenv.create_environment(venv_dir)
+    def __init__(self, dependency_builder=None):
+        # type: (Optional[DependencyBuilder]) -> None
+        self._osutils = OSUtils()
+        if dependency_builder is None:
+            dependency_builder = DependencyBuilder(self._osutils)
+        self._dependency_builder = dependency_builder
+
+    def _get_requirements_file(self, project_dir):
+        # type: (str) -> str
+        # Gets the path to a requirements.txt file out of a project dir path
+        return self._osutils.joinpath(project_dir, 'requirements.txt')
 
     def create_deployment_package(self, project_dir, package_filename=None):
         # type: (str, Optional[str]) -> str
         print("Creating deployment package.")
-        # pip install -t doesn't work out of the box with homebrew and
-        # python, so we're using virtualenvs instead which works in
-        # more cases.
-        venv_dir = os.path.join(project_dir, '.chalice', 'venv')
-        self._create_virtualenv(venv_dir)
-        pip_exe = compat.pip_script_in_venv(venv_dir)
-        assert os.path.isfile(pip_exe)
-        # Next install any requirements specified by the app.
-        requirements_file = os.path.join(project_dir, 'requirements.txt')
+        # Now we need to create a zip file and add in the site-packages
+        # dir first, followed by the app_dir contents next.
         deployment_package_filename = self.deployment_package_filename(
             project_dir)
         if package_filename is None:
             package_filename = deployment_package_filename
-        if self._has_at_least_one_package(requirements_file) and not \
-                os.path.isfile(package_filename):
-            p = subprocess.Popen([pip_exe, 'install', '-r', requirements_file],
-                                 stdout=subprocess.PIPE)
-            p.communicate()
-        deps_dir = compat.site_packages_dir_in_venv(venv_dir)
-        assert os.path.isdir(deps_dir)
-        # Now we need to create a zip file and add in the site-packages
-        # dir first, followed by the app_dir contents next.
-        dirname = os.path.dirname(os.path.abspath(package_filename))
-        if not os.path.isdir(dirname):
-            os.makedirs(dirname)
+        try:
+            self._dependency_builder.build_site_packages(project_dir)
+        except MissingDependencyError as e:
+            missing_packages = '\n'.join([p.identifier for p
+                                          in e.missing])
+            print(MISSING_DEPENDENCIES_TEMPLATE % missing_packages)
+        site_packages_dir = self._dependency_builder.site_package_dir(
+            project_dir)
+        dirname = self._osutils.dirname(
+            self._osutils.abspath(package_filename))
+        if not self._osutils.directory_exists(dirname):
+            self._osutils.makedirs(dirname)
         with zipfile.ZipFile(package_filename, 'w',
                              compression=zipfile.ZIP_DEFLATED) as z:
-            self._add_py_deps(z, deps_dir)
+            self._add_py_deps(z, site_packages_dir)
             self._add_app_files(z, project_dir)
-            self._add_vendor_files(z, os.path.join(project_dir,
-                                                   self._VENDOR_DIR))
+            self._add_vendor_files(z, self._osutils.joinpath(project_dir,
+                                                             self._VENDOR_DIR))
         return package_filename
 
     def _add_vendor_files(self, zipped, dirname):
         # type: (zipfile.ZipFile, str) -> None
-        if not os.path.isdir(dirname):
+        if not self._osutils.directory_exists(dirname):
             return
         prefix_len = len(dirname) + 1
-        for root, _, filenames in os.walk(dirname):
+        for root, _, filenames in self._osutils.walk(dirname):
             for filename in filenames:
-                full_path = os.path.join(root, filename)
+                full_path = self._osutils.joinpath(root, filename)
                 zip_path = full_path[prefix_len:]
                 zipped.write(full_path, zip_path)
-
-    def _has_at_least_one_package(self, filename):
-        # type: (str) -> bool
-        if not os.path.isfile(filename):
-            return False
-        with open(filename, 'r') as f:
-            # This is meant to be a best effort attempt.
-            # This can return True and still have no packages
-            # actually being specified, but those aren't common
-            # cases.
-            for line in f:
-                line = line.strip()
-                if line and not line.startswith('#'):
-                    return True
-        return False
 
     def deployment_package_filename(self, project_dir):
         # type: (str) -> str
@@ -89,10 +96,11 @@ class LambdaDeploymentPackager(object):
         # based on a hash of the requirements file.
         # This is done so that we only "pip install -r requirements.txt"
         # when we know there's new dependencies we need to install.
-        requirements_file = os.path.join(project_dir, 'requirements.txt')
+        requirements_file = self._get_requirements_file(project_dir)
         hash_contents = self._hash_project_dir(
-            requirements_file, os.path.join(project_dir, self._VENDOR_DIR))
-        deployment_package_filename = os.path.join(
+            requirements_file, self._osutils.joinpath(project_dir,
+                                                      self._VENDOR_DIR))
+        deployment_package_filename = self._osutils.joinpath(
             project_dir, '.chalice', 'deployments', hash_contents + '.zip')
         return deployment_package_filename
 
@@ -105,7 +113,7 @@ class LambdaDeploymentPackager(object):
                 # what we want to include in _add_app_files.
                 dirnames.remove('chalice')
             for filename in filenames:
-                full_path = os.path.join(root, filename)
+                full_path = self._osutils.joinpath(root, filename)
                 zip_path = full_path[prefix_len:]
                 zip_fileobj.write(full_path, zip_path)
 
@@ -121,7 +129,7 @@ class LambdaDeploymentPackager(object):
             chalice_init = chalice_init[:-1]
         zip_fileobj.write(chalice_init, 'chalice/__init__.py')
 
-        zip_fileobj.write(os.path.join(project_dir, 'app.py'),
+        zip_fileobj.write(self._osutils.joinpath(project_dir, 'app.py'),
                           'app.py')
         self._add_chalice_lib_if_needed(project_dir, zip_fileobj)
 
@@ -180,7 +188,7 @@ class LambdaDeploymentPackager(object):
         print("Regen deployment package...")
         tmpzip = deployment_package_filename + '.tmp.zip'
         with zipfile.ZipFile(deployment_package_filename, 'r') as inzip:
-            with zipfile.ZipFile(tmpzip, 'w') as outzip:
+            with zipfile.ZipFile(tmpzip, 'w', zipfile.ZIP_DEFLATED) as outzip:
                 for el in inzip.infolist():
                     if self._needs_latest_version(el.filename):
                         continue
@@ -208,3 +216,373 @@ class LambdaDeploymentPackager(object):
                         self._CHALICE_LIB_DIR,
                         fullpath[len(libdir) + 1:])
                     zip_fileobj.write(fullpath, zip_path)
+
+
+class DependencyBuilder(object):
+    """Build site-packages by manually downloading and unpacking whls.
+
+    Pip is used to download all the dependency sdists. Then wheels that
+    compatible with lambda are downloaded. Any source packages that do not
+    have a matching wheel file are built into a wheel and that file is checked
+    for compatibility with the lambda python runtime environment.
+
+    All compatible wheels that are downloaded/built this way are unpacked
+    into a site-packages directory, to be included in the bundle by the
+    packager.
+    """
+    _MANYLINUX_COMPATIBLE_PLAT = {'any', 'linux_x86_64', 'manylinux1_x86_64'}
+
+    def __init__(self, osutils, pip_runner=None):
+        # type: (OSUtils, Optional[PipRunner]) -> None
+        self._osutils = osutils
+        if pip_runner is None:
+            pip_runner = PipRunner(SubprocessPip())
+        self._pip = pip_runner
+
+    def _valid_lambda_whl(self, filename):
+        # type: (str) -> bool
+        whl = filename[:-4]
+        implementation, abi, platform = whl.split('-')[-3:]
+        # Verify platform is compatible
+        if platform not in self._MANYLINUX_COMPATIBLE_PLAT:
+            return False
+        # Verify that the ABI is compatible with lambda. Either none or the
+        # correct type for the python version cp27mu for py27 and cp36m for
+        # py36.
+        if abi == 'none':
+            return True
+        prefix_version = implementation[:3]
+        if prefix_version == 'cp3':
+            # Deploying python 3 function which means we need cp36m abi
+            return abi == 'cp36m'
+        elif prefix_version == 'cp2':
+            # Deploying to python 2 function which means we need cp27mu abi
+            return abi == 'cp27mu'
+        # Don't know what we have but it didn't pass compatibility tests.
+        return False
+
+    def _has_at_least_one_package(self, filename):
+        # type: (str) -> bool
+        if not self._osutils.file_exists(filename):
+            return False
+        with open(filename, 'r') as f:
+            # This is meant to be a best effort attempt.
+            # This can return True and still have no packages
+            # actually being specified, but those aren't common
+            # cases.
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith('#'):
+                    return True
+        return False
+
+    def _download_all_dependencies(self, requirements_file, directory):
+        # type: (str, str) -> set[Package]
+        # Download dependencies prefering wheel files but falling back to
+        # raw source dependences to get the transitive closure over
+        # the dependency graph. Return the set of all package objects
+        # which will serve as the master list of dependencies needed to deploy
+        # successfully.
+        self._pip.download_all_dependencies(requirements_file, directory)
+        deps = {Package(directory, filename) for filename
+                in self._osutils.get_directory_contents(directory)}
+        return deps
+
+    def _download_binary_wheels(self, packages, directory):
+        # type: (set[Package], str) -> None
+        # Try to get binary whls for each package that isn't compatible.
+        self._pip.download_manylinux_whls(
+            [pkg.identifier for pkg in packages], directory)
+
+    def _build_sdists(self, sdists, directory):
+        # type: (set[Package], str) -> None
+        for sdist in sdists:
+            path_to_sdist = self._osutils.joinpath(directory, sdist.filename)
+            self._pip.build_wheel(path_to_sdist, directory)
+
+    def _categorize_whl_files(self, directory):
+        # type: (str) -> Tuple[Set[Package], Set[Package]]
+        final_whls = [Package(directory, filename) for filename
+                      in self._osutils.get_directory_contents(directory)
+                      if filename.endswith('.whl')]
+        valid_whls, invalid_whls = set(), set()
+        for whl in final_whls:
+            if self._valid_lambda_whl(whl.filename):
+                valid_whls.add(whl)
+            else:
+                invalid_whls.add(whl)
+        return valid_whls, invalid_whls
+
+    def _download_dependencies(self, directory, requirements_file):
+        # type: (str, str) -> Tuple[Set[Package], Set[Package]]
+        # Download all dependencies we can, letting pip choose what to download
+        deps = self._download_all_dependencies(requirements_file, directory)
+
+        # Sort the downloaded packages into three categories:
+        # - sdists (Pip could not get a wheel so it gave us a sdist)
+        # - valid whls (lambda compatbile wheel files)
+        # - invalid whls (lambda incompatible wheel files)
+        valid_whls, invalid_whls = self._categorize_whl_files(directory)
+        sdists = deps - valid_whls - invalid_whls
+
+        # Find which packages we do not yet have a valid whl file for. And
+        # try to download them specifically with lambda.
+        missing_whls = sdists | invalid_whls
+        self._download_binary_wheels(missing_whls, directory)
+
+        # Re-count the whl files after the second download pass. Anything
+        # that has a sdist but not a valid whl file is still missing and needs
+        # to be built from source into a wheel file.
+        valid_whls, invalid_whls = self._categorize_whl_files(directory)
+        missing_whls = sdists - valid_whls
+        self._build_sdists(missing_whls, directory)
+
+        # Final pass to find the valid whl files and see if there are any
+        # unmet dependencies left over. At this point there is nothing we can
+        # do about any missing wheel files.
+        valid_whls, _ = self._categorize_whl_files(directory)
+        missing_whls = deps - valid_whls
+        return valid_whls, missing_whls
+
+    def _install_purelib_and_platlib(self, whl, root):
+        # type: (Package, str) -> None
+        # Take a wheel package and the directory it was just unpacked into and
+        # properly unpackage the purelib and platlib subdirectories if they
+        # are present.
+        data_dir = self._osutils.joinpath(root, whl.data_dir)
+        if not self._osutils.directory_exists(data_dir):
+            return
+        unpack_dirs = {'purelib', 'platlib'}
+        data_contents = self._osutils.get_directory_contents(data_dir)
+        for content_name in data_contents:
+            if content_name in unpack_dirs:
+                source = self._osutils.joinpath(data_dir, content_name)
+                self._osutils.copytree(source, root)
+                # No reason to keep the purelib/platlib source directory around
+                # so we delete it to conserve space in the package.
+                self._osutils.rmtree(source)
+
+    def _install_whls(self, src_dir, dst_dir, whls):
+        # type: (str, str, Set[Package]) -> None
+        if os.path.isdir(dst_dir):
+            shutil.rmtree(dst_dir)
+        os.makedirs(dst_dir)
+        for whl in whls:
+            zipfile_path = self._osutils.joinpath(src_dir, whl.filename)
+            with zipfile.ZipFile(zipfile_path, 'r') as z:
+                z.extractall(dst_dir)
+            self._install_purelib_and_platlib(whl, dst_dir)
+
+    def build_site_packages(self, project_dir):
+        # type: (str) -> None
+        requirements_file = self._osutils.joinpath(
+            project_dir, 'requirements.txt')
+        deps_dir = self.site_package_dir(project_dir)
+        if self._has_at_least_one_package(requirements_file):
+            with self._osutils.tempdir() as tempdir:
+                valid_whls, missing_whls = self._download_dependencies(
+                    tempdir, requirements_file)
+                self._install_whls(tempdir, deps_dir, valid_whls)
+            if missing_whls:
+                raise MissingDependencyError(missing_whls)
+
+    def site_package_dir(self, project_dir):
+        # type: (str) -> str
+        """Return path to the site packages directory."""
+        deps_dir = self._osutils.joinpath(
+            project_dir, '.chalice', 'site-packages')
+        return deps_dir
+
+
+class Package(object):
+    PYPI_SDIST_EXTS = ['.zip', '.tar.gz']
+
+    def __init__(self, directory, filename):
+        # type: (str, str) -> None
+        self.dist_type = 'whl' if filename.endswith('whl') else 'sdist'
+        self.filename = filename
+        self._directory = directory
+        self._name, self._version = self._calculate_name_and_version()
+
+    @property
+    def data_dir(self):
+        # type: () -> str
+        # The directory format is {distribution}-{version}.data
+        return '%s-%s.data' % (self._name, self._version)
+
+    @property
+    def identifier(self):
+        # type: () -> str
+        return '%s==%s' % (self._name, self._version)
+
+    def __str__(self):
+        # type: () -> str
+        return '%s(%s)' % (self.identifier, self.dist_type)
+
+    def __repr__(self):
+        # type: () -> str
+        return str(self)
+
+    def __eq__(self, other):
+        # type: (Any) -> bool
+        return self.identifier == other.identifier
+
+    def __hash__(self):
+        # type: () -> int
+        return hash(self.identifier)
+
+    def _calculate_name_and_version(self):
+        # type: () -> Tuple[str, str]
+        if self.dist_type == 'whl':
+            # From the wheel spec (PEP 427)
+            # {distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-
+            # {platform tag}.whl
+            name, version = self.filename.split('-')[:2]
+        else:
+            info_fetcher = SdistMetadataFetcher()
+            name, version = info_fetcher.get_package_name_and_version(
+                self._directory, self.filename)
+        return name, version
+
+
+class SdistMetadataFetcher(object):
+    """This is the "correct" way to get name and version from an sdist."""
+    # https://git.io/vQkwV
+    _SETUPTOOLS_SHIM = (
+        "import setuptools, tokenize;__file__=%r;"
+        "f=getattr(tokenize, 'open', open)(__file__);"
+        "code=f.read().replace('\\r\\n', '\\n');"
+        "f.close();"
+        "exec(compile(code, __file__, 'exec'))"
+    )
+
+    def __init__(self, osutils=None):
+        # type: (OSUtils) -> None
+        if osutils is None:
+            osutils = OSUtils()
+        self._osutils = osutils
+
+    def _parse_pkg_info_file(self, filepath):
+        # type: (str) -> Message
+        with open(filepath, 'r') as f:
+            data = f.read()
+        parser = FeedParser()
+        parser.feed(data)
+        return parser.close()
+
+    def _generate_egg_info(self, package_dir):
+        # type: (str) -> str
+        setup_py = self._osutils.joinpath(package_dir, 'setup.py')
+        script = self._SETUPTOOLS_SHIM % setup_py
+
+        cmd = [sys.executable, '-c', script, '--no-user-cfg', 'egg_info']
+        egg_info_dir = self._osutils.joinpath(package_dir, 'egg-info')
+        self._osutils.makedirs(egg_info_dir)
+        cmd += ['--egg-base', 'egg-info']
+        p = subprocess.Popen(cmd, cwd=package_dir,
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p.communicate()
+        self._osutils.joinpath(egg_info_dir)
+        info_contents = self._osutils.get_directory_contents(egg_info_dir)
+        assert len(info_contents) == 1
+        pkg_info_path = self._osutils.joinpath(
+            egg_info_dir, info_contents[0], 'PKG-INFO')
+        return pkg_info_path
+
+    def _unpack_sdist_into_dir(self, sdist_path, unpack_dir):
+        # type: (str, str) -> str
+        if sdist_path.endswith('zip'):
+            with zipfile.ZipFile(sdist_path, 'r') as z:
+                z.extractall(unpack_dir)
+        elif sdist_path.endswith('.tar.gz'):
+            with tarfile.open(sdist_path, 'r:gz') as tar:
+                tar.extractall(unpack_dir)
+        else:
+            raise InvalidSourceDistributionNameError(sdist_path)
+        # There should only be one directory unpacked.
+        contents = self._osutils.get_directory_contents(unpack_dir)
+        assert len(contents) == 1
+        return self._osutils.joinpath(unpack_dir, contents[0])
+
+    def get_package_name_and_version(self, directory, filename):
+        # type: (str, str) -> Tuple[str, str]
+        sdist_path = self._osutils.joinpath(directory, filename)
+        with self._osutils.tempdir() as tempdir:
+            package_dir = self._unpack_sdist_into_dir(sdist_path, tempdir)
+            pkg_info_filepath = self._generate_egg_info(package_dir)
+            metadata = self._parse_pkg_info_file(pkg_info_filepath)
+            name = metadata['Name']
+            version = metadata['Version']
+        return name, version
+
+
+class PipWrapper(object):
+    def main(self, args):
+        # type: (List[str]) -> Tuple[Optional[bytes], Optional[bytes]]
+        raise NotImplementedError('PipWrapper.main')
+
+
+class SubprocessPip(PipWrapper):
+    """Wrapper around calling pip through a subprocess."""
+    def main(self, args):
+        # type: (List[str]) -> Tuple[Optional[bytes], Optional[bytes]]
+        python_exe = sys.executable
+        invoke_pip = [python_exe, '-m', 'pip']
+        invoke_pip.extend(args)
+        p = subprocess.Popen(invoke_pip,
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = p.communicate()
+        return out, err
+
+
+class PipRunner(object):
+    """Wrapper around pip calls used by chalice."""
+
+    def __init__(self, pip):
+        # type: (PipWrapper) -> None
+        self._wrapped_pip = pip
+
+    def _execute(self, command, args):
+        # type: (str, List[str]) -> None
+        """Execute a pip command with the given arguments."""
+        main_args = [command] + args
+        _, err = self._wrapped_pip.main(main_args)
+        if err:
+            if b'ReadTimeoutError' in err:
+                raise PipError('Read time out downloading dependencies.')
+            if b'NewConnectionError' in err:
+                raise PipError('Failed to establish a new connection when '
+                               'downloading dependencies.')
+            if b'PermissionError' in err:
+                match = re.search("Permission denied: '(.+?)'", str(err))
+                raise PipError('Do not have permissions to write to %s.'
+                               % match.group(1))
+
+    def build_wheel(self, wheel, directory):
+        # type: (str, str) -> None
+        """Build an sdist into a wheel file."""
+        arguments = ['--no-deps', '--wheel-dir', directory, wheel]
+        self._execute('wheel', arguments)
+
+    def download_all_dependencies(self, requirements_file, directory):
+        # type: (str, str) -> None
+        """Download all dependencies as sdist or whl."""
+        arguments = ['-r', requirements_file, '--dest', directory]
+        self._execute('download', arguments)
+
+    def download_manylinux_whls(self, packages, directory):
+        # type: (List[str], str) -> None
+        """Download wheel files for manylinux for all the given packages."""
+        # If any one of these dependencies fails pip will bail out. Since we
+        # are only interested in all the ones we can download, we need to feed
+        # each package to pip individually. The return code of pip doesn't
+        # matter here since we will inspect the working directory to see which
+        # wheels were downloaded. We are only interested in wheel files
+        # compatible with lambda, which means manylinux1_x86_64 platform and
+        # cpython implementation. The compatible abi depends on the python
+        # version and is checked later.
+        for package in packages:
+            arguments = ['--only-binary=:all:', '--no-deps', '--platform',
+                         'manylinux1_x86_64', '--implementation', 'cp',
+                         '--abi', lambda_abi, '--dest', directory, package]
+            self._execute('download', arguments)

--- a/chalice/package.py
+++ b/chalice/package.py
@@ -200,7 +200,7 @@ class AppPackager(object):
         # Deployment package
         zip_file = os.path.join(outdir, 'deployment.zip')
         self._lambda_packaager.create_deployment_package(
-            config.project_dir, zip_file)
+            config.project_dir, config.lambda_python_version, zip_file)
 
         # SAM template
         sam_template = self._sam_templater.generate_sam_template(

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -1,8 +1,11 @@
 import os
 import zipfile
 import json
+import contextlib
+import tempfile
+import shutil
 
-from typing import IO, Dict, Any  # noqa
+from typing import IO, Dict, List, Any, Tuple, Iterator  # noqa
 
 from chalice.constants import WELCOME_PROMPT
 
@@ -100,6 +103,60 @@ class OSUtils(object):
             mode = 'w'
         with open(filename, mode) as f:
             f.write(contents)
+
+    def directory_exists(self, path):
+        # type: (str) -> bool
+        return os.path.isdir(path)
+
+    def get_directory_contents(self, path):
+        # type: (str) -> List[str]
+        return os.listdir(path)
+
+    def makedirs(self, path):
+        # type: (str) -> None
+        os.makedirs(path)
+
+    def dirname(self, path):
+        # type: (str) -> str
+        return os.path.dirname(path)
+
+    def abspath(self, path):
+        # type: (str) -> str
+        return os.path.abspath(path)
+
+    def joinpath(self, *args):
+        # type: (str) -> str
+        return os.path.join(*args)
+
+    def walk(self, path):
+        # type: (str) -> Iterator[Tuple[str, List[str], List[str]]]
+        return os.walk(path)
+
+    def copytree(self, source, destination):
+        # type: (str, str) -> None
+        if not os.path.exists(destination):
+            os.makedirs(destination)
+        names = os.listdir(source)
+        for name in names:
+            new_source = os.path.join(source, name)
+            new_destination = os.path.join(destination, name)
+            if os.path.isdir(new_source):
+                self.copytree(new_source, new_destination)
+            else:
+                shutil.copy2(new_source, new_destination)
+
+    def rmtree(self, directory):
+        # type: (str) -> None
+        shutil.rmtree(directory)
+
+    @contextlib.contextmanager
+    def tempdir(self):
+        # type: () -> Any
+        tempdir = tempfile.mkdtemp()
+        try:
+            yield tempdir
+        finally:
+            shutil.rmtree(tempdir)
 
 
 def getting_started_prompt(prompter):

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -75,6 +75,10 @@ class OSUtils(object):
         # type: (str, str) -> IO
         return open(filename, mode)
 
+    def open_zip(self, filename, mode, compression=ZIP_DEFLATED):
+        # type: (str, str, int) -> zipfile.ZipFile
+        return zipfile.ZipFile(filename, mode, compression=compression)
+
     def remove_file(self, filename):
         # type: (str) -> None
         """Remove a file, noop if file does not exist."""
@@ -98,15 +102,6 @@ class OSUtils(object):
         with open(filename, mode) as f:
             return f.read()
 
-    @contextlib.contextmanager
-    def get_file_context(self, filename, mode='r'):
-        # type: (str, str) -> Iterator[BinaryIO]
-        try:
-            f = open(filename, mode)
-            yield f
-        finally:
-            f.close()
-
     def set_file_contents(self, filename, contents, binary=True):
         # type: (str, str, bool) -> None
         if binary:
@@ -116,22 +111,12 @@ class OSUtils(object):
         with open(filename, mode) as f:
             f.write(contents)
 
-    def unpack_zipfile(self, zipfile_path, unpack_dir):
+    def extract_zipfile(self, zipfile_path, unpack_dir):
         # type: (str, str) -> None
         with zipfile.ZipFile(zipfile_path, 'r') as z:
             z.extractall(unpack_dir)
 
-    @contextlib.contextmanager
-    def zipfile_context(self, filename, mode='r',
-                        compression=zipfile.ZIP_STORED):
-        # type: (str, str, int) -> Iterator[zipfile.ZipFile]
-        try:
-            z = zipfile.ZipFile(filename, mode=mode, compression=compression)
-            yield z
-        finally:
-            z.close()
-
-    def unpack_tarfile(self, tarfile_path, unpack_dir):
+    def extract_tarfile(self, tarfile_path, unpack_dir):
         # type: (str, str) -> None
         with tarfile.open(tarfile_path, 'r:gz') as tar:
             tar.extractall(unpack_dir)

--- a/docs/source/topics/packaging.rst
+++ b/docs/source/topics/packaging.rst
@@ -102,17 +102,43 @@ Below shows an example of how to use the
 `cryptography <https://pypi.python.org/pypi/cryptography>`__ package in a
 Chalice app for the ``python3.6`` lambda environment.
 
-We're going to leverage the ``vendor/`` directory in order to use this package
-in our app. We can't use the ``requirements.txt`` file because ``cryptography``
-requires C Extensions and does not have wheel files available on PyPi.
+Suppose you are on a Mac or Windows and want to deploy a Chalice app that
+depends on the ``cryptography`` package. If you simply add it to your
+``requirements.txt`` file and try to deploy it with ``chalice deploy`` you will
+get the following warning during deployment::
 
-You can do this yourself by building ``cryptography`` yourself on an Amazon
-Linux instance running in EC2. All of the following commands were run inside
-a ``python 3.6`` virtual environment.
+  $ cat requirements.txt
+  cryptography
+  $ chalice deploy
+  Updating IAM policy.
+  Updating lambda function...
+  Creating deployment package.
 
-* Download the source first using ``pip download cryptography`` which will
-  download all the requirements into the current working directory. The
-  directory should have the following contents:
+  Could not install dependencies:
+  cryptography==1.9
+  You will have to build these yourself and vendor them in
+  the chalice vendor folder.
+
+  Your deployment will continue but may not work correctly
+  if missing dependencies are not present. For more information:
+  http://chalice.readthedocs.io/en/latest/topics/packaging.html
+
+This happened because the ``cryptography`` package does not yet have wheel
+files availble on PyPi, and has C extensions. Since we are not on the same
+platform as AWS Lambda, the compiled C extensions Chalice built were not
+compatible. To get around this we are going to leverage the ``vendor/``
+directory, and build the ``cryptography`` package on a compatible linux system.
+
+You can do this yourself by building ``cryptography`` on an Amazon Linux
+instance running in EC2. All of the following commands were run inside a
+``python 3.6`` virtual environment.
+
+* Download the source first::
+
+    $ pip download cryptography
+
+  This will download all the requirements into the current working directory.
+  The directory should have the following contents:
 
   * ``asn1crypto-0.22.0-py2.py3-none-any.whl``
   * ``cffi-1.10.0-cp36-cp36m-manylinux1_x86_64.whl``
@@ -127,10 +153,12 @@ a ``python 3.6`` virtual environment.
   downloading them. That leaves ``cryptography`` itself and ``pycparser`` as
   the only two that did not have a wheel file available for download.
 
-* Next build the ``cryptography`` source into a wheel file running the command
-  ``pip wheel cryptography-1.9.tar.gz``. This will take a few seconds and build
-  a wheel file for both ``cryptography`` and ``pycparser``. The directory
-  should now have two additional wheel files:
+* Next build the ``cryptography`` source package into a wheel file::
+
+    $ pip wheel cryptography-1.9.tar.gz
+
+  This will take a few seconds and build a wheel file for both ``cryptography``
+  and ``pycparser``. The directory should now have two additional wheel files:
 
   * ``cryptography-1.9-cp36-cp36m-linux_x86_64.whl``
   * ``pycparser-2.17-py2.py3-none-any.whl``

--- a/docs/source/topics/packaging.rst
+++ b/docs/source/topics/packaging.rst
@@ -1,7 +1,7 @@
 App Packaging
 =============
 
-In order to deploy your chalice app, a zip file is created that
+In order to deploy your Chalice app, a zip file is created that
 contains your application and all third party packages your application
 rqeuires.  This file is used by AWS Lambda and is referred
 to as a deployment package.
@@ -34,10 +34,11 @@ write yourself.
 
 There are two options for handling python package dependencies:
 
-* **requirements.txt** - During the packaging process, chalice will
-  run ``pip install -r requirements.txt`` in a virtual environment
-  and automatically install 3rd party python packages into the deployment
-  package.
+* **requirements.txt** - During the packaging process, Chalice will
+  install any packages it finds or can build compatible wheels for.
+  Specifically all pure python packages as well as all packages that upload
+  wheel files for the ``manylinux1_x86_64`` platform will be automatically
+  installable.
 * **vendor/** - The *contents* of this directory are automatically added to
   the top level of the deployment package.
 
@@ -48,7 +49,7 @@ specific examples).  The ``vendor/`` directory is helpful in these scenarios:
 
 * You need to include custom packages or binary content that is not accessible
   via ``pip``.  These may be internal packages that aren't public.
-* You need to use C extensions, and you're not developing on Linux.
+* Wheel files are not available for a package you need from pip.
 
 
 As a general rule of thumb, code that you write goes in either ``app.py`` or
@@ -94,54 +95,82 @@ This directory structure is then zipped up and sent to AWS Lambda during the
 deployment process.
 
 
-Psycopg2 Example
-----------------
+Cryptography Example
+--------------------
 
-Below shows an example of how you can use the
-`psycopg2 <https://pypi.python.org/pypi/psycopg2>`__ package in a chalice app.
+Below shows an example of how to use the
+`cryptography <https://pypi.python.org/pypi/cryptography>`__ package in a
+Chalice app for the ``python3.6`` lambda environment.
 
-We're going to leverage the ``vendor/`` directory in order to use this
-package in our app.  We can't use ``requirements.txt`` file because
-``psycopg2`` has additional requirements:
+We're going to leverage the ``vendor/`` directory in order to use this package
+in our app. We can't use the ``requirements.txt`` file because ``cryptography``
+requires C Extensions and does not have wheel files available on PyPi.
 
-* It contains C extensions and if you're not developing on Amazon Linux,
-  the binaries built on a dev machine will not match what's needed on AWS
-  Lambda.
-* AWS Lambda does not have the ``libpq.so`` library available, so we need
-  to build a custom version of ``psycopg2`` that has ``libpq.so`` statically
-  linked.
+You can do this yourself by building ``cryptography`` yourself on an Amazon
+Linux instance running in EC2. All of the following commands were run inside
+a ``python 3.6`` virtual environment.
 
-You can do this yourself by building `psycopg2 <https://pypi.python.org/pypi/psycopg2>`__
-on Amazon Linux with the ``static_libpq=1`` value set in the ``setup.cfg``
-file.  You can then copy/unzip the ``.whl`` file into the ``vendor/``
-directory.
+* Download the source first using ``pip download cryptography`` which will
+  download all the requirements into the current working directory. The
+  directory should have the following contents:
 
-There are also existing packages that have prebuilt this, including the
-3rd party `awslambda-psycopg2 <https://github.com/jkehler/awslambda-psycopg2>`__
-package.  If you wanted to use this 3rd party package you can follow these
-steps::
+  * ``asn1crypto-0.22.0-py2.py3-none-any.whl``
+  * ``cffi-1.10.0-cp36-cp36m-manylinux1_x86_64.whl``
+  * ``cryptography-1.9.tar.gz``
+  * ``idna-2.5-py2.py3-none-any.whl``
+  * ``pycparser-2.17.tar.gz``
+  * ``six-1.10.0-py2.py3-none-any.whl``
 
-$ mkdir vendor
-$ git clone git@github.com:jkehler/awslambda-psycopg2.git
-$ cp -r awslambda-psycopg2/psycopg2 vendor/
-$ rm -rf awslambda-psycopg2/
+  This is a complete set of dependencies required for the cryptography package.
+  Most of these packages have wheels that were downloaded, which means they can
+  simply be put in the ``requirements.txt`` and Chalice will take care of
+  downloading them. That leaves ``cryptography`` itself and ``pycparser`` as
+  the only two that did not have a wheel file available for download.
 
+* Next build the ``cryptography`` source into a wheel file running the command
+  ``pip wheel cryptography-1.9.tar.gz``. This will take a few seconds and build
+  a wheel file for both ``cryptography`` and ``pycparser``. The directory
+  should now have two additional wheel files:
 
-You should now have a directory that looks like this::
+  * ``cryptography-1.9-cp36-cp36m-linux_x86_64.whl``
+  * ``pycparser-2.17-py2.py3-none-any.whl``
 
-    $ tree
-    .
-    ├── app.py
-    ├── app.pyc
-    ├── requirements.txt
-    └── vendor
-        └── psycopg2
-            ├── __init__.py
-            ├── _json.py
-            ├── _psycopg.so
-            ....
+  The ``cryptography`` wheel file has been built with a compatible
+  archictecture for lambda (``linux_x86_64``) and the ``pycparser`` has been
+  built for ``any`` architecture which means it can also be automatically be
+  packaged by Chalice if it is listed in the ``requirements.txt`` file.
 
+* Download the ``cryptography`` wheel file from the Amazon Linux instance and
+  unzip it into the ``vendor/`` directory in the root directory of Chalice.
 
-In your ``app.py`` file you can now import ``psycopg2``, and this
-dependency will automatically be included when the ``chalice deploy``
-command is run.
+  You should now have a project directory that looks like this::
+
+     $ tree
+     .
+     ├── app.py
+     ├── requirements.txt
+     └── vendor
+         ├── cryptography
+         │   ├── ... Lots of files
+         │
+         └── cryptography-1.9.dist-info
+             ├── DESCRIPTION.rst
+             ├── METADATA
+             ├── RECORD
+             ├── WHEEL
+             ├── entry_points.txt
+             ├── metadata.json
+             └── top_level.txt
+
+  The ``requirements.txt`` file should look like this::
+
+    $ cat requirements.txt
+    cffi==1.10.0
+    six==1.10.0
+    asn1crypto==0.22.0
+    idna==2.5
+    pycparser==2.17
+
+  In your ``app.py`` file you can now import ``cryptography``, and these
+  dependencies will all get included when the ``chalice deploy`` command is
+  run.

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ with open('README.rst') as readme_file:
 install_requires = [
     'click==6.6',
     'botocore>=1.5.40,<2.0.0',
-    'virtualenv>=15.0.0,<16.0.0',
     'typing==3.5.3.0',
     'six>=1.10.0,<2.0.0',
+    'pip>=9'
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     'botocore>=1.5.40,<2.0.0',
     'typing==3.5.3.0',
     'six>=1.10.0,<2.0.0',
-    'pip>=9'
+    'pip>=9,<10'
 ]
 
 setup(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,32 @@
+import zipfile
+
 import botocore.session
 from botocore.stub import Stubber
-import mock
-import pytest
 from pytest import fixture
+
+
+class FakeSdistBuilder(object):
+    _SETUP_PY = (
+        'from setuptools import setup\n'
+        'setup(\n'
+        '    name="%s",\n'
+        '    version="%s"\n'
+        ')\n'
+    )
+
+    def write_fake_sdist(self, directory, name, version):
+        filename = '%s-%s.zip' % (name, version)
+        path = '%s/%s' % (directory, filename)
+        with zipfile.ZipFile(path, 'w',
+                             compression=zipfile.ZIP_DEFLATED) as z:
+            z.writestr('sdist/setup.py', self._SETUP_PY % (name, version))
+        return directory, filename
+
+
+@fixture
+def sdist_builder():
+    s = FakeSdistBuilder()
+    return s
 
 
 def pytest_addoption(parser):

--- a/tests/functional/test_package.py
+++ b/tests/functional/test_package.py
@@ -11,7 +11,6 @@ from chalice.deploy.packager import PipRunner
 from chalice.deploy.packager import DependencyBuilder
 from chalice.deploy.packager import Package
 from chalice.deploy.packager import MissingDependencyError
-from chalice.deploy.packager import PipWrapper
 from chalice.compat import lambda_abi
 from chalice.utils import OSUtils
 from tests.conftest import FakeSdistBuilder
@@ -45,7 +44,7 @@ class PathArgumentEndingWith(object):
         return False
 
 
-class FakePip(PipWrapper):
+class FakePip(object):
     def __init__(self):
         self._calls = defaultdict(lambda: [])
         self._call_history = []
@@ -61,7 +60,7 @@ class FakePip(PipWrapper):
                 side_effect.execute(args)
         except IndexError:
             pass
-        return b'', b''
+        return 0, b''
 
     def packages_to_download(self, expected_args, packages,
                              whl_contents=None):
@@ -174,8 +173,8 @@ class TestDependencyBuilder(object):
             ]
         )
 
-        builder.build_site_packages(appdir)
-        site_packages = builder.site_package_dir(appdir)
+        site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
+        builder.build_site_packages(requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -193,11 +192,11 @@ class TestDependencyBuilder(object):
             packages=[
                 'foo-1.2-cp36-cp36m-manylinux1_x86_64.whl'
             ],
-            whl_contents=['{data_dir}/purelib/foo/placeholder']
+            whl_contents=['foo-1.2.data/purelib/foo/']
         )
 
-        builder.build_site_packages(appdir)
-        site_packages = builder.site_package_dir(appdir)
+        site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
+        builder.build_site_packages(requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -215,11 +214,11 @@ class TestDependencyBuilder(object):
             packages=[
                 'foo-1.2-cp36-cp36m-manylinux1_x86_64.whl'
             ],
-            whl_contents=['{data_dir}/platlib/foo/placeholder']
+            whl_contents=['foo-1.2.data/platlib/foo/']
         )
 
-        builder.build_site_packages(appdir)
-        site_packages = builder.site_package_dir(appdir)
+        site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
+        builder.build_site_packages(requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -240,13 +239,13 @@ class TestDependencyBuilder(object):
                 'foo-1.2-cp36-cp36m-manylinux1_x86_64.whl'
             ],
             whl_contents=[
-                '{data_dir}/platlib/foo/placeholder',
-                '{data_dir}/purelib/bar/placeholder'
+                'foo-1.2.data/platlib/foo/',
+                'foo-1.2.data/purelib/bar/'
             ]
         )
 
-        builder.build_site_packages(appdir)
-        site_packages = builder.site_package_dir(appdir)
+        site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
+        builder.build_site_packages(requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -267,13 +266,13 @@ class TestDependencyBuilder(object):
                 'foo-1.2-cp36-cp36m-manylinux1_x86_64.whl'
             ],
             whl_contents=[
-                '{package_name}/placeholder',
-                '{data_dir}/data/bar/placeholder'
+                'foo/placeholder',
+                'foo-1.2.data/data/bar/'
             ]
         )
 
-        builder.build_site_packages(appdir)
-        site_packages = builder.site_package_dir(appdir)
+        site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
+        builder.build_site_packages(requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -295,13 +294,13 @@ class TestDependencyBuilder(object):
                 'foo-1.2-cp36-cp36m-manylinux1_x86_64.whl'
             ],
             whl_contents=[
-                '{package_name}/placeholder',
-                '{data_dir}/includes/bar/placeholder'
+                'foo/placeholder',
+                'foo.1.2.data/includes/bar/'
             ]
         )
 
-        builder.build_site_packages(appdir)
-        site_packages = builder.site_package_dir(appdir)
+        site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
+        builder.build_site_packages(requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -328,8 +327,8 @@ class TestDependencyBuilder(object):
             ]
         )
 
-        builder.build_site_packages(appdir)
-        site_packages = builder.site_package_dir(appdir)
+        site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
+        builder.build_site_packages(requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -358,8 +357,8 @@ class TestDependencyBuilder(object):
             ]
         )
 
-        builder.build_site_packages(appdir)
-        site_packages = builder.site_package_dir(appdir)
+        site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
+        builder.build_site_packages(requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -381,8 +380,8 @@ class TestDependencyBuilder(object):
             ]
         )
 
-        builder.build_site_packages(appdir)
-        site_packages = builder.site_package_dir(appdir)
+        site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
+        builder.build_site_packages(requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -404,8 +403,8 @@ class TestDependencyBuilder(object):
             ]
         )
 
-        builder.build_site_packages(appdir)
-        site_packages = builder.site_package_dir(appdir)
+        site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
+        builder.build_site_packages(requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -426,9 +425,9 @@ class TestDependencyBuilder(object):
             ]
         )
 
+        site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
         with pytest.raises(MissingDependencyError) as e:
-            builder.build_site_packages(appdir)
-        site_packages = builder.site_package_dir(appdir)
+            builder.build_site_packages(requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         missing_pacakges = list(e.value.missing)
@@ -450,9 +449,9 @@ class TestDependencyBuilder(object):
             ]
         )
 
+        site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
         with pytest.raises(MissingDependencyError) as e:
-            builder.build_site_packages(appdir)
-        site_packages = builder.site_package_dir(appdir)
+            builder.build_site_packages(requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         missing_pacakges = list(e.value.missing)
@@ -487,9 +486,8 @@ class TestDependencyBuilder(object):
                 'bar-1.2-cp36-cp36m-manylinux1_x86_64.whl'
             ]
         )
-
-        builder.build_site_packages(appdir)
-        site_packages = builder.site_package_dir(appdir)
+        site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
+        builder.build_site_packages(requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -518,9 +516,8 @@ class TestDependencyBuilder(object):
                 'foo-1.2-cp36-none-any.whl'
             ]
         )
-
-        builder.build_site_packages(appdir)
-        site_packages = builder.site_package_dir(appdir)
+        site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
+        builder.build_site_packages(requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         pip.validate()
@@ -553,10 +550,9 @@ class TestDependencyBuilder(object):
                 'foo-1.2-cp36-cp36m-macosx_10_6_intel.whl'
             ]
         )
-
+        site_packages = os.path.join(appdir, '.chalice.', 'site-packages')
         with pytest.raises(MissingDependencyError) as e:
-            builder.build_site_packages(appdir)
-        site_packages = builder.site_package_dir(appdir)
+            builder.build_site_packages(requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         # bar should succeed and foo should failed.
@@ -605,8 +601,7 @@ class TestDependencyBuilder(object):
         bar = os.path.join(site_packages, 'bar')
         os.makedirs(bar)
         with pytest.raises(MissingDependencyError) as e:
-            builder.build_site_packages(appdir)
-        site_packages = builder.site_package_dir(appdir)
+            builder.build_site_packages(requirements_file, site_packages)
         installed_packages = os.listdir(site_packages)
 
         # bar should succeed and foo should failed.

--- a/tests/functional/test_package.py
+++ b/tests/functional/test_package.py
@@ -1,9 +1,20 @@
 import os
+import zipfile
+import mock
+from collections import defaultdict
 
+import pytest
 from chalice.config import Config
 from chalice import Chalice
 from chalice import package
-
+from chalice.deploy.packager import PipRunner
+from chalice.deploy.packager import DependencyBuilder
+from chalice.deploy.packager import Package
+from chalice.deploy.packager import MissingDependencyError
+from chalice.deploy.packager import PipWrapper
+from chalice.compat import lambda_abi
+from chalice.utils import OSUtils
+from tests.conftest import FakeSdistBuilder
 
 
 def _create_app_structure(tmpdir):
@@ -21,6 +32,589 @@ def sample_app():
         return {"hello": "world"}
 
     return app
+
+
+class PathArgumentEndingWith(object):
+    def __init__(self, filename):
+        self._filename = filename
+
+    def __eq__(self, other):
+        if isinstance(other, str):
+            filename = os.path.split(other)[-1]
+            return self._filename == filename
+        return False
+
+
+class FakePip(PipWrapper):
+    def __init__(self):
+        self._calls = defaultdict(lambda: [])
+        self._call_history = []
+        self._side_effects = defaultdict(lambda: [])
+
+    def main(self, args):
+        cmd, args = args[0], args[1:]
+        self._calls[cmd].append(args)
+        try:
+            side_effects = self._side_effects[cmd].pop(0)
+            for side_effect in side_effects:
+                self._call_history.append((args, side_effect.expected_args))
+                side_effect.execute(args)
+        except IndexError:
+            pass
+        return b'', b''
+
+    def packages_to_download(self, expected_args, packages,
+                             whl_contents=None):
+        side_effects = [PipSideEffect(pkg,
+                                      '--dest',
+                                      expected_args,
+                                      whl_contents)
+                        for pkg in packages]
+        self._side_effects['download'].append(side_effects)
+
+    def wheels_to_build(self, expected_args, wheels_to_build):
+        side_effects = [PipSideEffect(pkg, '--wheel-dir', expected_args)
+                        for pkg in wheels_to_build]
+        self._side_effects['wheel'].append(side_effects)
+
+    @property
+    def calls(self):
+        return self._calls
+
+    def validate(self):
+        for call in self._call_history:
+            actual_args, expected_args = call
+            assert expected_args == actual_args
+
+
+class PipSideEffect(object):
+    def __init__(self, filename, dirarg, expected_args, whl_contents=None):
+        self._filename = filename
+        self._package_name = filename.split('-')[0]
+        self._dirarg = dirarg
+        self.expected_args = expected_args
+        if whl_contents is None:
+            whl_contents = ['{package_name}/placeholder']
+        self._whl_contents = whl_contents
+
+    def _build_fake_whl(self, directory, filename):
+        filepath = os.path.join(directory, filename)
+        if not os.path.isfile(filepath):
+            package = Package(directory, filename)
+            with zipfile.ZipFile(filepath, 'w') as z:
+                for content_path in self._whl_contents:
+                    z.writestr(content_path.format(
+                        package_name=self._package_name,
+                        data_dir=package.data_dir
+                    ), b'')
+
+    def _build_fake_sdist(self, filepath):
+        # tar.gz is the same no reason to test it here as it is tested in
+        # unit.deploy.TestSdistMetadataFetcher
+        assert filepath.endswith('zip')
+        components = os.path.split(filepath)
+        prefix, filename = components[:-1], components[-1]
+        directory = os.path.join(*prefix)
+        filename_without_ext = filename[:-4]
+        pkg_name, pkg_version = filename_without_ext.split('-')
+        builder = FakeSdistBuilder()
+        builder.write_fake_sdist(directory, pkg_name, pkg_version)
+
+    def execute(self, args):
+        """Generate the file in the target_dir."""
+        if self._dirarg:
+            target_dir = None
+            for i, arg in enumerate(args):
+                if arg == self._dirarg:
+                    target_dir = args[i+1]
+            if target_dir:
+                filepath = os.path.join(target_dir, self._filename)
+                if filepath.endswith('.whl'):
+                    self._build_fake_whl(target_dir, self._filename)
+                else:
+                    self._build_fake_sdist(filepath)
+
+
+@pytest.fixture
+def osutils():
+    return OSUtils()
+
+
+@pytest.fixture
+def pip_runner():
+    pip = FakePip()
+    pip_runner = PipRunner(pip)
+    return pip, pip_runner
+
+
+class TestDependencyBuilder(object):
+    def _write_requirements_txt(self, packages, directory):
+        contents = '\n'.join(packages)
+        filepath = os.path.join(directory, 'requirements.txt')
+        with open(filepath, 'w') as f:
+            f.write(contents)
+
+    def _make_appdir_and_dependency_builder(self, reqs, tmpdir, runner):
+        appdir = str(_create_app_structure(tmpdir))
+        self._write_requirements_txt(reqs, appdir)
+        builder = DependencyBuilder(OSUtils(), runner)
+        return appdir, builder
+
+    def test_can_get_whls_all_manylinux(self, tmpdir, pip_runner):
+        reqs = ['foo', 'bar']
+        pip, runner = pip_runner
+        appdir, builder = self._make_appdir_and_dependency_builder(
+            reqs, tmpdir, runner)
+        requirements_file = os.path.join(appdir, 'requirements.txt')
+        pip.packages_to_download(
+            expected_args=['-r', requirements_file, '--dest', mock.ANY],
+            packages=[
+                'foo-1.2-cp36-cp36m-manylinux1_x86_64.whl',
+                'bar-1.2-cp36-cp36m-manylinux1_x86_64.whl'
+            ]
+        )
+
+        builder.build_site_packages(appdir)
+        site_packages = builder.site_package_dir(appdir)
+        installed_packages = os.listdir(site_packages)
+
+        pip.validate()
+        for req in reqs:
+            assert req in installed_packages
+
+    def test_can_expand_purelib_whl(self, tmpdir, pip_runner):
+        reqs = ['foo']
+        pip, runner = pip_runner
+        appdir, builder = self._make_appdir_and_dependency_builder(
+            reqs, tmpdir, runner)
+        requirements_file = os.path.join(appdir, 'requirements.txt')
+        pip.packages_to_download(
+            expected_args=['-r', requirements_file, '--dest', mock.ANY],
+            packages=[
+                'foo-1.2-cp36-cp36m-manylinux1_x86_64.whl'
+            ],
+            whl_contents=['{data_dir}/purelib/foo/placeholder']
+        )
+
+        builder.build_site_packages(appdir)
+        site_packages = builder.site_package_dir(appdir)
+        installed_packages = os.listdir(site_packages)
+
+        pip.validate()
+        for req in reqs:
+            assert req in installed_packages
+
+    def test_can_expand_platlib_whl(self, tmpdir, pip_runner):
+        reqs = ['foo']
+        pip, runner = pip_runner
+        appdir, builder = self._make_appdir_and_dependency_builder(
+            reqs, tmpdir, runner)
+        requirements_file = os.path.join(appdir, 'requirements.txt')
+        pip.packages_to_download(
+            expected_args=['-r', requirements_file, '--dest', mock.ANY],
+            packages=[
+                'foo-1.2-cp36-cp36m-manylinux1_x86_64.whl'
+            ],
+            whl_contents=['{data_dir}/platlib/foo/placeholder']
+        )
+
+        builder.build_site_packages(appdir)
+        site_packages = builder.site_package_dir(appdir)
+        installed_packages = os.listdir(site_packages)
+
+        pip.validate()
+        for req in reqs:
+            assert req in installed_packages
+
+    def test_can_expand_platlib_and_purelib(self, tmpdir, pip_runner):
+        # This wheel installs two importable libraries foo and bar, one from
+        # the wheels purelib and one from its platlib.
+        reqs = ['foo', 'bar']
+        pip, runner = pip_runner
+        appdir, builder = self._make_appdir_and_dependency_builder(
+            reqs, tmpdir, runner)
+        requirements_file = os.path.join(appdir, 'requirements.txt')
+        pip.packages_to_download(
+            expected_args=['-r', requirements_file, '--dest', mock.ANY],
+            packages=[
+                'foo-1.2-cp36-cp36m-manylinux1_x86_64.whl'
+            ],
+            whl_contents=[
+                '{data_dir}/platlib/foo/placeholder',
+                '{data_dir}/purelib/bar/placeholder'
+            ]
+        )
+
+        builder.build_site_packages(appdir)
+        site_packages = builder.site_package_dir(appdir)
+        installed_packages = os.listdir(site_packages)
+
+        pip.validate()
+        for req in reqs:
+            assert req in installed_packages
+
+    def test_does_ignore_data(self, tmpdir, pip_runner):
+        # Make sure the wheel installer does not copy the data directory
+        # up to the root.
+        reqs = ['foo']
+        pip, runner = pip_runner
+        appdir, builder = self._make_appdir_and_dependency_builder(
+            reqs, tmpdir, runner)
+        requirements_file = os.path.join(appdir, 'requirements.txt')
+        pip.packages_to_download(
+            expected_args=['-r', requirements_file, '--dest', mock.ANY],
+            packages=[
+                'foo-1.2-cp36-cp36m-manylinux1_x86_64.whl'
+            ],
+            whl_contents=[
+                '{package_name}/placeholder',
+                '{data_dir}/data/bar/placeholder'
+            ]
+        )
+
+        builder.build_site_packages(appdir)
+        site_packages = builder.site_package_dir(appdir)
+        installed_packages = os.listdir(site_packages)
+
+        pip.validate()
+        for req in reqs:
+            assert req in installed_packages
+        assert 'bar' not in installed_packages
+
+    def test_does_ignore_include(self, tmpdir, pip_runner):
+        # Make sure the wheel installer does not copy the includes directory
+        # up to the root.
+        reqs = ['foo']
+        pip, runner = pip_runner
+        appdir, builder = self._make_appdir_and_dependency_builder(
+            reqs, tmpdir, runner)
+        requirements_file = os.path.join(appdir, 'requirements.txt')
+        pip.packages_to_download(
+            expected_args=['-r', requirements_file, '--dest', mock.ANY],
+            packages=[
+                'foo-1.2-cp36-cp36m-manylinux1_x86_64.whl'
+            ],
+            whl_contents=[
+                '{package_name}/placeholder',
+                '{data_dir}/includes/bar/placeholder'
+            ]
+        )
+
+        builder.build_site_packages(appdir)
+        site_packages = builder.site_package_dir(appdir)
+        installed_packages = os.listdir(site_packages)
+
+        pip.validate()
+        for req in reqs:
+            assert req in installed_packages
+        assert 'bar' not in installed_packages
+
+    def test_does_ignore_scripts(self, tmpdir, pip_runner):
+        # Make sure the wheel isntaller does not copy the scripts directory
+        # up to the root.
+        reqs = ['foo']
+        pip, runner = pip_runner
+        appdir, builder = self._make_appdir_and_dependency_builder(
+            reqs, tmpdir, runner)
+        requirements_file = os.path.join(appdir, 'requirements.txt')
+        pip.packages_to_download(
+            expected_args=['-r', requirements_file, '--dest', mock.ANY],
+            packages=[
+                'foo-1.2-cp36-cp36m-manylinux1_x86_64.whl'
+            ],
+            whl_contents=[
+                '{package_name}/placeholder',
+                '{data_dir}/scripts/bar/placeholder'
+            ]
+        )
+
+        builder.build_site_packages(appdir)
+        site_packages = builder.site_package_dir(appdir)
+        installed_packages = os.listdir(site_packages)
+
+        pip.validate()
+        for req in reqs:
+            assert req in installed_packages
+        assert 'bar' not in installed_packages
+
+    def test_can_expand_platlib_and_platlib_and_root(self, tmpdir, pip_runner):
+        # This wheel installs three import names foo, bar and baz.
+        # they are from the root install directory and the platlib and purelib
+        # subdirectories in the platlib.
+        reqs = ['foo', 'bar', 'baz']
+        pip, runner = pip_runner
+        appdir, builder = self._make_appdir_and_dependency_builder(
+            reqs, tmpdir, runner)
+        requirements_file = os.path.join(appdir, 'requirements.txt')
+        pip.packages_to_download(
+            expected_args=['-r', requirements_file, '--dest', mock.ANY],
+            packages=[
+                'foo-1.2-cp36-cp36m-manylinux1_x86_64.whl'
+            ],
+            whl_contents=[
+                '{package_name}/placeholder',
+                '{data_dir}/platlib/bar/placeholder',
+                '{data_dir}/purelib/baz/placeholder'
+            ]
+        )
+
+        builder.build_site_packages(appdir)
+        site_packages = builder.site_package_dir(appdir)
+        installed_packages = os.listdir(site_packages)
+
+        pip.validate()
+        for req in reqs:
+            assert req in installed_packages
+
+    def test_can_get_whls_mixed_compat(self, tmpdir, osutils, pip_runner):
+        reqs = ['foo', 'bar', 'baz']
+        pip, runner = pip_runner
+        appdir, builder = self._make_appdir_and_dependency_builder(
+            reqs, tmpdir, runner)
+        requirements_file = os.path.join(appdir, 'requirements.txt')
+        pip.packages_to_download(
+            expected_args=['-r', requirements_file, '--dest', mock.ANY],
+            packages=[
+                'foo-1.0-cp36-none-any.whl',
+                'bar-1.2-cp36-cp36m-manylinux1_x86_64.whl',
+                'baz-1.5-cp36-cp36m-linux_x86_64.whl'
+            ]
+        )
+
+        builder.build_site_packages(appdir)
+        site_packages = builder.site_package_dir(appdir)
+        installed_packages = os.listdir(site_packages)
+
+        pip.validate()
+        for req in reqs:
+            assert req in installed_packages
+
+    def test_can_get_py27_whls(self, tmpdir, osutils, pip_runner):
+        reqs = ['foo', 'bar', 'baz']
+        pip, runner = pip_runner
+        appdir, builder = self._make_appdir_and_dependency_builder(
+            reqs, tmpdir, runner)
+        requirements_file = os.path.join(appdir, 'requirements.txt')
+        pip.packages_to_download(
+            expected_args=['-r', requirements_file, '--dest', mock.ANY],
+            packages=[
+                'foo-1.0-cp27-none-any.whl',
+                'bar-1.2-cp27-none-manylinux1_x86_64.whl',
+                'baz-1.5-cp27-cp27mu-linux_x86_64.whl'
+            ]
+        )
+
+        builder.build_site_packages(appdir)
+        site_packages = builder.site_package_dir(appdir)
+        installed_packages = os.listdir(site_packages)
+
+        pip.validate()
+        for req in reqs:
+            assert req in installed_packages
+
+    def test_does_fail_on_narrow_py27_unicode(self, tmpdir, osutils,
+                                              pip_runner):
+        reqs = ['baz']
+        pip, runner = pip_runner
+        appdir, builder = self._make_appdir_and_dependency_builder(
+            reqs, tmpdir, runner)
+        requirements_file = os.path.join(appdir, 'requirements.txt')
+        pip.packages_to_download(
+            expected_args=['-r', requirements_file, '--dest', mock.ANY],
+            packages=[
+                'baz-1.5-cp27-cp27m-linux_x86_64.whl'
+            ]
+        )
+
+        with pytest.raises(MissingDependencyError) as e:
+            builder.build_site_packages(appdir)
+        site_packages = builder.site_package_dir(appdir)
+        installed_packages = os.listdir(site_packages)
+
+        missing_pacakges = list(e.value.missing)
+        pip.validate()
+        assert len(missing_pacakges) == 1
+        assert missing_pacakges[0].identifier == 'baz==1.5'
+        assert len(installed_packages) == 0
+
+    def test_does_fail_on_python_1_whl(self, tmpdir, osutils, pip_runner):
+        reqs = ['baz']
+        pip, runner = pip_runner
+        appdir, builder = self._make_appdir_and_dependency_builder(
+            reqs, tmpdir, runner)
+        requirements_file = os.path.join(appdir, 'requirements.txt')
+        pip.packages_to_download(
+            expected_args=['-r', requirements_file, '--dest', mock.ANY],
+            packages=[
+                'baz-1.5-cp14-cp14m-linux_x86_64.whl'
+            ]
+        )
+
+        with pytest.raises(MissingDependencyError) as e:
+            builder.build_site_packages(appdir)
+        site_packages = builder.site_package_dir(appdir)
+        installed_packages = os.listdir(site_packages)
+
+        missing_pacakges = list(e.value.missing)
+        pip.validate()
+        assert len(missing_pacakges) == 1
+        assert missing_pacakges[0].identifier == 'baz==1.5'
+        assert len(installed_packages) == 0
+
+    def test_can_replace_incompat_whl(self, tmpdir, osutils, pip_runner):
+        reqs = ['foo', 'bar']
+        pip, runner = pip_runner
+        appdir, builder = self._make_appdir_and_dependency_builder(
+            reqs, tmpdir, runner)
+        requirements_file = os.path.join(appdir, 'requirements.txt')
+        pip.packages_to_download(
+            expected_args=['-r', requirements_file, '--dest', mock.ANY],
+            packages=[
+                'foo-1.0-cp36-none-any.whl',
+                'bar-1.2-cp36-cp36m-macosx_10_6_intel.whl'
+            ]
+        )
+        # Once the initial download has 1 incompatible whl file. The second,
+        # more targeted download, finds manylinux1_x86_64 and downloads that.
+        pip.packages_to_download(
+            expected_args=[
+                '--only-binary=:all:', '--no-deps', '--platform',
+                'manylinux1_x86_64', '--implementation', 'cp',
+                '--abi', lambda_abi, '--dest', mock.ANY,
+                'bar==1.2'
+            ],
+            packages=[
+                'bar-1.2-cp36-cp36m-manylinux1_x86_64.whl'
+            ]
+        )
+
+        builder.build_site_packages(appdir)
+        site_packages = builder.site_package_dir(appdir)
+        installed_packages = os.listdir(site_packages)
+
+        pip.validate()
+        for req in reqs:
+            assert req in installed_packages
+
+    def test_can_build_sdist(self, tmpdir, osutils, pip_runner):
+        reqs = ['foo', 'bar']
+        pip, runner = pip_runner
+        appdir, builder = self._make_appdir_and_dependency_builder(
+            reqs, tmpdir, runner)
+        requirements_file = os.path.join(appdir, 'requirements.txt')
+        pip.packages_to_download(
+            expected_args=['-r', requirements_file, '--dest', mock.ANY],
+            packages=[
+                'foo-1.2.zip',
+                'bar-1.2-cp36-cp36m-manylinux1_x86_64.whl'
+            ]
+        )
+        # Foo is built from and is pure python so it yields a compatible
+        # wheel file.
+        pip.wheels_to_build(
+            expected_args=['--no-deps', '--wheel-dir', mock.ANY,
+                           PathArgumentEndingWith('foo-1.2.zip')],
+            wheels_to_build=[
+                'foo-1.2-cp36-none-any.whl'
+            ]
+        )
+
+        builder.build_site_packages(appdir)
+        site_packages = builder.site_package_dir(appdir)
+        installed_packages = os.listdir(site_packages)
+
+        pip.validate()
+        for req in reqs:
+            assert req in installed_packages
+
+    def test_build_sdist_makes_incompatible_whl(self, tmpdir, osutils,
+                                                pip_runner):
+        reqs = ['foo', 'bar']
+        pip, runner = pip_runner
+        appdir, builder = self._make_appdir_and_dependency_builder(
+            reqs, tmpdir, runner)
+        requirements_file = os.path.join(appdir, 'requirements.txt')
+        pip.packages_to_download(
+            expected_args=['-r', requirements_file, '--dest', mock.ANY],
+            packages=[
+                'foo-1.2.zip',
+                'bar-1.2-cp36-cp36m-manylinux1_x86_64.whl'
+            ]
+        )
+        # foo is compiled since downloading it failed to get any wheels. And
+        # the second download for manylinux1_x86_64 wheels failed as well.
+        # building in this case yields a platform specific wheel file that is
+        # not compatible. In this case currently there is nothing that chalice
+        # can do to install this package.
+        pip.wheels_to_build(
+            expected_args=['--no-deps', '--wheel-dir', mock.ANY,
+                           PathArgumentEndingWith('foo-1.2.zip')],
+            wheels_to_build=[
+                'foo-1.2-cp36-cp36m-macosx_10_6_intel.whl'
+            ]
+        )
+
+        with pytest.raises(MissingDependencyError) as e:
+            builder.build_site_packages(appdir)
+        site_packages = builder.site_package_dir(appdir)
+        installed_packages = os.listdir(site_packages)
+
+        # bar should succeed and foo should failed.
+        missing_pacakges = list(e.value.missing)
+        pip.validate()
+        assert len(missing_pacakges) == 1
+        assert missing_pacakges[0].identifier == 'foo==1.2'
+        assert installed_packages == ['bar']
+
+    def test_build_into_existing_dir_with_preinstalled_packages(
+            self, tmpdir, osutils, pip_runner):
+        # Same test as above so we should get foo failing and bar succeeding
+        # but in this test we started with a .chalice/site-packages directory
+        # with both foo and bar already installed. It should still fail since
+        # they may be there by happenstance, or from an incompatible version
+        # of python.
+        reqs = ['foo', 'bar']
+        pip, runner = pip_runner
+        appdir, builder = self._make_appdir_and_dependency_builder(
+            reqs, tmpdir, runner)
+        requirements_file = os.path.join(appdir, 'requirements.txt')
+        pip.packages_to_download(
+            expected_args=['-r', requirements_file, '--dest', mock.ANY],
+            packages=[
+                'foo-1.2.zip',
+                'bar-1.2-cp36-cp36m-manylinux1_x86_64.whl'
+            ]
+        )
+        pip.packages_to_download(
+            expected_args=[
+                '--only-binary=:all:', '--no-deps', '--platform',
+                'manylinux1_x86_64', '--implementation', 'cp',
+                '--abi', lambda_abi, '--dest', mock.ANY,
+                'foo==1.2'
+            ],
+            packages=[
+                'foo-1.2-cp36-cp36m-macosx_10_6_intel.whl'
+            ]
+        )
+
+        # Add two fake packages foo and bar that have previously been
+        # installed in the site-packages directory.
+        site_packages = os.path.join(appdir, '.chalice', 'site-packages')
+        foo = os.path.join(site_packages, 'foo')
+        os.makedirs(foo)
+        bar = os.path.join(site_packages, 'bar')
+        os.makedirs(bar)
+        with pytest.raises(MissingDependencyError) as e:
+            builder.build_site_packages(appdir)
+        site_packages = builder.site_package_dir(appdir)
+        installed_packages = os.listdir(site_packages)
+
+        # bar should succeed and foo should failed.
+        missing_pacakges = list(e.value.missing)
+        pip.validate()
+        assert len(missing_pacakges) == 1
+        assert missing_pacakges[0].identifier == 'foo==1.2'
+        assert installed_packages == ['bar']
 
 
 def test_can_create_app_packager_with_no_autogen(tmpdir):

--- a/tests/functional/test_package.py
+++ b/tests/functional/test_package.py
@@ -110,7 +110,7 @@ class PipSideEffect(object):
     def _build_fake_sdist(self, filepath):
         # tar.gz is the same no reason to test it here as it is tested in
         # unit.deploy.TestSdistMetadataFetcher
-        assert filepath.endswith('zip')
+        assert filepath.endswith('.zip')
         components = os.path.split(filepath)
         prefix, filename = components[:-1], components[-1]
         directory = os.path.join(*prefix)

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -707,6 +707,56 @@ class TestDeployer(object):
         assert excinfo.match('Denied')
 
 
+def test_deployer_does_not_reuse_pacakge_on_python_version_change(
+        app_policy, sample_app):
+    osutils = InMemoryOSUtils({'packages.zip': b'package contents',
+                               'packages2.zip': b'rebuilt contents'})
+    aws_client = mock.Mock(spec=TypedAWSClient)
+    packager = mock.Mock(spec=LambdaDeploymentPackager)
+
+    packager.deployment_package_filename.return_value = 'packages.zip'
+    packager.create_deployment_package.return_value = 'packages2.zip'
+    # Given the lambda function already exists:
+    aws_client.lambda_function_exists.return_value = True
+    aws_client.update_function.return_value = {"FunctionArn": "myarn"}
+    # And given we don't want chalice to manage our iam role for the lambda
+    # function:
+    cfg = Config.create(
+        chalice_stage='dev',
+        chalice_app=sample_app,
+        manage_iam_role=False,
+        app_name='appname',
+        iam_role_arn='role-arn',
+        project_dir='./myproject',
+        environment_variables={"FOO": "BAR"},
+        lambda_timeout=120,
+        lambda_memory_size=256,
+        tags={'mykey': 'myvalue'}
+    )
+
+    # Pick a fake python version that will not match our current runtime under
+    # both 2.7 and 3.6.
+    aws_client.get_function_configuration.return_value = {
+        'Runtime': 'python1.0',
+    }
+    prompter = mock.Mock(spec=NoPrompt)
+    prompter.confirm.return_value = True
+
+    d = LambdaDeployer(aws_client, packager, prompter, osutils, app_policy)
+    lambda_function_name = 'lambda_function_name'
+    deployed = DeployedResources(
+        'api', 'api_handler_arn', lambda_function_name,
+        None, 'dev', None, None, {})
+    d.deploy(cfg, deployed, 'dev')
+
+    # Since the python version changed only the create_deployment_package
+    # method should be called. Injecting the lastest app would only get called
+    # if the python dependences could stay the same, so it must not be called
+    # in this case.
+    assert packager.create_deployment_package.called
+    assert packager.inject_latest_app.called is False
+
+
 def test_noprompt_always_returns_default():
     assert not NoPrompt().confirm("You sure you want to do this?",
                                   default=False)
@@ -1056,6 +1106,11 @@ class TestLambdaInitialDeploymentWithConfigurations(object):
             {self.package_name: self.package_contents})
         self.aws_client = mock.Mock(spec=TypedAWSClient)
         self.aws_client.create_function.side_effect = [self.lambda_arn]
+        # Return a python Runtime that will never match our local runtime so
+        # the deployment package is not reused.
+        self.aws_client.get_function_configuration.return_value = {
+            'Runtime': 'FakePythonVersion'
+        }
         self.packager = mock.Mock(LambdaDeploymentPackager)
         self.packager.create_deployment_package.return_value =\
             self.package_name

--- a/tests/unit/deploy/test_packager.py
+++ b/tests/unit/deploy/test_packager.py
@@ -8,11 +8,11 @@ import io
 from chalice.utils import OSUtils
 from chalice.deploy.packager import Package
 from chalice.deploy.packager import PipRunner
-from chalice.deploy.packager import DependencyBuilder
-from chalice.deploy.packager import SdistMetadataFetcher
+from chalice.deploy.packager import SDistMetadataFetcher
 from chalice.deploy.packager import InvalidSourceDistributionNameError
 from chalice.deploy.packager import SubprocessPip
-from chalice.deploy.packager import PipError
+from chalice.deploy.packager import NoSuchPackageError
+from chalice.deploy.packager import PackageDownloadError
 
 
 class FakePip(object):
@@ -24,7 +24,8 @@ class FakePip(object):
         self._calls.append(args)
         if self._returns:
             return self._returns.pop(0)
-        return b'', b''
+        # Return an rc of 0 and an empty stderr
+        return 0, b''
 
     def add_return(self, return_pair):
         self._returns.append(return_pair)
@@ -48,32 +49,27 @@ def osutils():
 
 @pytest.fixture
 def sdist_reader():
-    return SdistMetadataFetcher()
-
-
-class TestDependencyBuilder(object):
-    def test_site_package_dir_is_correct(self, osutils):
-        builder = DependencyBuilder(osutils)
-        root = os.path.join('tmp', 'foo', 'bar')
-        site_packages = builder.site_package_dir(root)
-        assert site_packages == os.path.join(
-            root, '.chalice', 'site-packages')
+    return SDistMetadataFetcher()
 
 
 class TestPackage(object):
-    def test_whl_package(self):
+    def test_can_create_package_with_custom_osutils(self, osutils):
+        pkg = Package('', 'foobar-1.0-py3-none-any.whl', osutils)
+        assert pkg._osutils == osutils
+
+    def test_wheel_package(self):
         filename = 'foobar-1.0-py3-none-any.whl'
         pkg = Package('', filename)
-        assert pkg.dist_type == 'whl'
+        assert pkg.dist_type == 'wheel'
         assert pkg.filename == filename
         assert pkg.identifier == 'foobar==1.0'
-        assert str(pkg) == 'foobar==1.0(whl)'
+        assert str(pkg) == 'foobar==1.0(wheel)'
 
     def test_invalid_package(self):
         with pytest.raises(InvalidSourceDistributionNameError):
             Package('', 'foobar.jpg')
 
-    def test_same_pkg_sdist_and_whl_collide(self, osutils, sdist_builder):
+    def test_same_pkg_sdist_and_wheel_collide(self, osutils, sdist_builder):
         with osutils.tempdir() as tempdir:
             sdist_builder.write_fake_sdist(tempdir, 'foobar', '1.0')
             pkgs = set()
@@ -91,11 +87,21 @@ class TestPackage(object):
         pkg = Package('', 'foobar-1.0-py3-none-any.whl')
         assert pkg == pkg
 
+    def test_pkg_is_eq_to_similar_pkg(self):
+        pure_pkg = Package('', 'foobar-1.0-py3-none-any.whl')
+        plat_pkg = Package('', 'foobar-1.0-py3-py36m-manylinux1_x86_64.whl')
+        assert pure_pkg == plat_pkg
+
+    def test_pkg_is_not_equal_to_different_type(self):
+        pkg = Package('', 'foobar-1.0-py3-none-any.whl')
+        non_package_type = 1
+        assert not (pkg == non_package_type)
+
     def test_pkg_repr(self):
         pkg = Package('', 'foobar-1.0-py3-none-any.whl')
-        assert repr(pkg) == 'foobar==1.0(whl)'
+        assert repr(pkg) == 'foobar==1.0(wheel)'
 
-    def test_whl_data_dir(self):
+    def test_wheel_data_dir(self):
         pkg = Package('', 'foobar-2.0-py3-none-any.whl')
         assert pkg.data_dir == 'foobar-2.0.data'
 
@@ -103,10 +109,10 @@ class TestPackage(object):
 class TestSubprocessPip(object):
     def test_can_invoke_pip(self):
         pip = SubprocessPip()
-        out, err = pip.main(['--version'])
+        rc, err = pip.main(['--version'])
         # Simple assertion that we can execute pip and it gives us some output
         # and nothing on stderr.
-        assert len(out) > 0
+        assert rc == 0
         assert err == b''
 
 
@@ -114,11 +120,11 @@ class TestPipRunner(object):
     def test_build_wheel(self, pip_runner):
         # Test that `pip wheel` is called with the correct params
         pip, runner = pip_runner
-        whl = 'foobar-1.0-py3-none-any.whl'
+        wheel = 'foobar-1.0-py3-none-any.whl'
         directory = 'directory'
-        runner.build_wheel(whl, directory)
+        runner.build_wheel(wheel, directory)
         assert pip.calls[0] == ['wheel', '--no-deps', '--wheel-dir',
-                                directory, whl]
+                                directory, wheel]
 
     def test_download_all_deps(self, pip_runner):
         # Make sure that `pip download` is called with the correct arguments
@@ -133,7 +139,7 @@ class TestPipRunner(object):
         # for getting lambda compatible wheels.
         pip, runner = pip_runner
         packages = ['foo', 'bar', 'baz']
-        runner.download_manylinux_whls(packages, 'directory')
+        runner.download_manylinux_wheels(packages, 'directory')
         if sys.version_info[0] == 2:
             abi = 'cp27mu'
         else:
@@ -147,32 +153,31 @@ class TestPipRunner(object):
 
     def test_download_wheels_no_wheels(self, pip_runner):
         pip, runner = pip_runner
-        runner.download_manylinux_whls([], 'directory')
+        runner.download_manylinux_wheels([], 'directory')
         assert len(pip.calls) == 0
 
-    def test_raise_timeout_error(self, pip_runner):
+    def test_raise_no_such_package_error(self, pip_runner):
         pip, runner = pip_runner
-        pip.add_return((b'', b'ReadTimeoutError'))
-        with pytest.raises(PipError) as einfo:
+        pip.add_return((1, (b'Could not find a version that satisfies the '
+                            b'requirement BadPackageName ')))
+        with pytest.raises(NoSuchPackageError) as einfo:
             runner.download_all_dependencies('requirements.txt', 'directory')
-        assert str(einfo.value) == 'Read time out downloading dependencies.'
+        assert str(einfo.value) == ('Could not satisfy the requirement: '
+                                    'BadPackageName')
 
-    def test_raise_new_connection_error(self, pip_runner):
+    def test_raise_other_unknown_error_during_downloads(self, pip_runner):
         pip, runner = pip_runner
-        pip.add_return((b'', b'NewConnectionError'))
-        with pytest.raises(PipError) as einfo:
+        pip.add_return((1, b'SomeNetworkingError: Details here.'))
+        with pytest.raises(PackageDownloadError) as einfo:
             runner.download_all_dependencies('requirements.txt', 'directory')
-        assert str(einfo.value) == ('Failed to establish a new connection '
-                                    'when downloading dependencies.')
+        assert str(einfo.value) == 'SomeNetworkingError: Details here.'
 
-    def test_raise_permission_error(self, pip_runner):
+    def test_inject_unknown_error_if_no_stderr(self, pip_runner):
         pip, runner = pip_runner
-        pip.add_return((b'', (b"PermissionError Permission denied: "
-                              b"'/foo/bar/baz.tar.gz'")))
-        with pytest.raises(PipError) as einfo:
+        pip.add_return((1, None))
+        with pytest.raises(PackageDownloadError) as einfo:
             runner.download_all_dependencies('requirements.txt', 'directory')
-        assert str(einfo.value) == ('Do not have permissions to write to '
-                                    '/foo/bar/baz.tar.gz.')
+        assert str(einfo.value) == 'Unknown error'
 
 
 class TestSdistMetadataFetcher(object):
@@ -205,17 +210,17 @@ class TestSdistMetadataFetcher(object):
                 tarinfo = tarfile.TarInfo('sdist/setup.py')
                 tarinfo.size = len(setup_py)
                 tar.addfile(tarinfo, io.BytesIO(setup_py.encode()))
-        return directory, filename
+        filepath = os.path.join(directory, filename)
+        return filepath
 
     def test_setup_tar_gz(self, osutils, sdist_reader):
         setup_py = self._SETUP_PY % (
             self._SETUPTOOLS, 'foo', '1.0'
         )
         with osutils.tempdir() as tempdir:
-            directory, filename = self._write_fake_sdist(
-                setup_py, tempdir, 'tar.gz')
+            filepath = self._write_fake_sdist(setup_py, tempdir, 'tar.gz')
             name, version = sdist_reader.get_package_name_and_version(
-                directory, filename)
+                filepath)
         assert name == 'foo'
         assert version == '1.0'
 
@@ -229,10 +234,9 @@ class TestSdistMetadataFetcher(object):
             self._SETUPTOOLS, 'foo-bar', '1.0-2b'
         )
         with osutils.tempdir() as tempdir:
-            directory, filename = self._write_fake_sdist(
-                setup_py, tempdir, 'tar.gz')
+            filepath = self._write_fake_sdist(setup_py, tempdir, 'tar.gz')
             name, version = sdist_reader.get_package_name_and_version(
-                directory, filename)
+                filepath)
         assert name == 'foo-bar'
         assert version == '1.0-2b'
 
@@ -241,10 +245,9 @@ class TestSdistMetadataFetcher(object):
             self._SETUPTOOLS, 'foo', '1.0'
         )
         with osutils.tempdir() as tempdir:
-            directory, filename = self._write_fake_sdist(
-                setup_py, tempdir, 'zip')
+            filepath = self._write_fake_sdist(setup_py, tempdir, 'zip')
             name, version = sdist_reader.get_package_name_and_version(
-                directory, filename)
+                filepath)
         assert name == 'foo'
         assert version == '1.0'
 
@@ -253,10 +256,9 @@ class TestSdistMetadataFetcher(object):
             self._DISTUTILS, 'foo', '1.0'
         )
         with osutils.tempdir() as tempdir:
-            directory, filename = self._write_fake_sdist(
-                setup_py, tempdir, 'tar.gz')
+            filepath = self._write_fake_sdist(setup_py, tempdir, 'tar.gz')
             name, version = sdist_reader.get_package_name_and_version(
-                directory, filename)
+                filepath)
         assert name == 'foo'
         assert version == '1.0'
 
@@ -265,10 +267,9 @@ class TestSdistMetadataFetcher(object):
             self._DISTUTILS, 'foo', '1.0'
         )
         with osutils.tempdir() as tempdir:
-            directory, filename = self._write_fake_sdist(
-                setup_py, tempdir, 'zip')
+            filepath = self._write_fake_sdist(setup_py, tempdir, 'zip')
             name, version = sdist_reader.get_package_name_and_version(
-                directory, filename)
+                filepath)
         assert name == 'foo'
         assert version == '1.0'
 
@@ -277,10 +278,9 @@ class TestSdistMetadataFetcher(object):
             self._BOTH, 'foo-bar', '1.0-2b'
         )
         with osutils.tempdir() as tempdir:
-            directory, filename = self._write_fake_sdist(
-                setup_py, tempdir, 'tar.gz')
+            filepath = self._write_fake_sdist(setup_py, tempdir, 'tar.gz')
             name, version = sdist_reader.get_package_name_and_version(
-                directory, filename)
+                filepath)
         assert name == 'foo-bar'
         assert version == '1.0-2b'
 
@@ -289,10 +289,9 @@ class TestSdistMetadataFetcher(object):
             self._BOTH, 'foo', '1.0'
         )
         with osutils.tempdir() as tempdir:
-            directory, filename = self._write_fake_sdist(
-                setup_py, tempdir, 'zip')
+            filepath = self._write_fake_sdist(setup_py, tempdir, 'zip')
             name, version = sdist_reader.get_package_name_and_version(
-                directory, filename)
+                filepath)
         assert name == 'foo'
         assert version == '1.0'
 
@@ -301,8 +300,7 @@ class TestSdistMetadataFetcher(object):
             self._BOTH, 'foo', '1.0'
         )
         with osutils.tempdir() as tempdir:
-            directory, filename = self._write_fake_sdist(
-                setup_py, tempdir, 'tar.gz2')
+            filepath = self._write_fake_sdist(setup_py, tempdir, 'tar.gz2')
             with pytest.raises(InvalidSourceDistributionNameError):
                 name, version = sdist_reader.get_package_name_and_version(
-                    directory, filename)
+                    filepath)

--- a/tests/unit/deploy/test_packager.py
+++ b/tests/unit/deploy/test_packager.py
@@ -1,0 +1,308 @@
+import sys
+import os
+import pytest
+import zipfile
+import tarfile
+import io
+
+from chalice.utils import OSUtils
+from chalice.deploy.packager import Package
+from chalice.deploy.packager import PipRunner
+from chalice.deploy.packager import DependencyBuilder
+from chalice.deploy.packager import SdistMetadataFetcher
+from chalice.deploy.packager import InvalidSourceDistributionNameError
+from chalice.deploy.packager import SubprocessPip
+from chalice.deploy.packager import PipError
+
+
+class FakePip(object):
+    def __init__(self):
+        self._calls = []
+        self._returns = []
+
+    def main(self, args):
+        self._calls.append(args)
+        if self._returns:
+            return self._returns.pop(0)
+        return b'', b''
+
+    def add_return(self, return_pair):
+        self._returns.append(return_pair)
+
+    @property
+    def calls(self):
+        return self._calls
+
+
+@pytest.fixture
+def pip_runner():
+    pip = FakePip()
+    pip_runner = PipRunner(pip)
+    return pip, pip_runner
+
+
+@pytest.fixture
+def osutils():
+    return OSUtils()
+
+
+@pytest.fixture
+def sdist_reader():
+    return SdistMetadataFetcher()
+
+
+class TestDependencyBuilder(object):
+    def test_site_package_dir_is_correct(self, osutils):
+        builder = DependencyBuilder(osutils)
+        root = os.path.join('tmp', 'foo', 'bar')
+        site_packages = builder.site_package_dir(root)
+        assert site_packages == os.path.join(
+            root, '.chalice', 'site-packages')
+
+
+class TestPackage(object):
+    def test_whl_package(self):
+        filename = 'foobar-1.0-py3-none-any.whl'
+        pkg = Package('', filename)
+        assert pkg.dist_type == 'whl'
+        assert pkg.filename == filename
+        assert pkg.identifier == 'foobar==1.0'
+        assert str(pkg) == 'foobar==1.0(whl)'
+
+    def test_invalid_package(self):
+        with pytest.raises(InvalidSourceDistributionNameError):
+            Package('', 'foobar.jpg')
+
+    def test_same_pkg_sdist_and_whl_collide(self, osutils, sdist_builder):
+        with osutils.tempdir() as tempdir:
+            sdist_builder.write_fake_sdist(tempdir, 'foobar', '1.0')
+            pkgs = set()
+            pkgs.add(Package('', 'foobar-1.0-py3-none-any.whl'))
+            pkgs.add(Package(tempdir, 'foobar-1.0.zip'))
+            assert len(pkgs) == 1
+
+    def test_diff_pkg_sdist_and_whl_do_not_collide(self):
+        pkgs = set()
+        pkgs.add(Package('', 'foobar-1.0-py3-none-any.whl'))
+        pkgs.add(Package('', 'badbaz-1.0-py3-none-any.whl'))
+        assert len(pkgs) == 2
+
+    def test_same_pkg_is_eq(self):
+        pkg = Package('', 'foobar-1.0-py3-none-any.whl')
+        assert pkg == pkg
+
+    def test_pkg_repr(self):
+        pkg = Package('', 'foobar-1.0-py3-none-any.whl')
+        assert repr(pkg) == 'foobar==1.0(whl)'
+
+    def test_whl_data_dir(self):
+        pkg = Package('', 'foobar-2.0-py3-none-any.whl')
+        assert pkg.data_dir == 'foobar-2.0.data'
+
+
+class TestSubprocessPip(object):
+    def test_can_invoke_pip(self):
+        pip = SubprocessPip()
+        out, err = pip.main(['--version'])
+        # Simple assertion that we can execute pip and it gives us some output
+        # and nothing on stderr.
+        assert len(out) > 0
+        assert err == b''
+
+
+class TestPipRunner(object):
+    def test_build_wheel(self, pip_runner):
+        # Test that `pip wheel` is called with the correct params
+        pip, runner = pip_runner
+        whl = 'foobar-1.0-py3-none-any.whl'
+        directory = 'directory'
+        runner.build_wheel(whl, directory)
+        assert pip.calls[0] == ['wheel', '--no-deps', '--wheel-dir',
+                                directory, whl]
+
+    def test_download_all_deps(self, pip_runner):
+        # Make sure that `pip download` is called with the correct arguments
+        # for getting all sdists.
+        pip, runner = pip_runner
+        runner.download_all_dependencies('requirements.txt', 'directory')
+        assert pip.calls[0] == ['download', '-r',
+                                'requirements.txt', '--dest', 'directory']
+
+    def test_download_wheels(self, pip_runner):
+        # Make sure that `pip download` is called with the correct arguments
+        # for getting lambda compatible wheels.
+        pip, runner = pip_runner
+        packages = ['foo', 'bar', 'baz']
+        runner.download_manylinux_whls(packages, 'directory')
+        if sys.version_info[0] == 2:
+            abi = 'cp27mu'
+        else:
+            abi = 'cp36m'
+        expected_prefix = ['download', '--only-binary=:all:', '--no-deps',
+                           '--platform', 'manylinux1_x86_64',
+                           '--implementation', 'cp', '--abi', abi,
+                           '--dest', 'directory']
+        for i, package in enumerate(packages):
+            assert pip.calls[i] == expected_prefix + [package]
+
+    def test_download_wheels_no_wheels(self, pip_runner):
+        pip, runner = pip_runner
+        runner.download_manylinux_whls([], 'directory')
+        assert len(pip.calls) == 0
+
+    def test_raise_timeout_error(self, pip_runner):
+        pip, runner = pip_runner
+        pip.add_return((b'', b'ReadTimeoutError'))
+        with pytest.raises(PipError) as einfo:
+            runner.download_all_dependencies('requirements.txt', 'directory')
+        assert str(einfo.value) == 'Read time out downloading dependencies.'
+
+    def test_raise_new_connection_error(self, pip_runner):
+        pip, runner = pip_runner
+        pip.add_return((b'', b'NewConnectionError'))
+        with pytest.raises(PipError) as einfo:
+            runner.download_all_dependencies('requirements.txt', 'directory')
+        assert str(einfo.value) == ('Failed to establish a new connection '
+                                    'when downloading dependencies.')
+
+    def test_raise_permission_error(self, pip_runner):
+        pip, runner = pip_runner
+        pip.add_return((b'', (b"PermissionError Permission denied: "
+                              b"'/foo/bar/baz.tar.gz'")))
+        with pytest.raises(PipError) as einfo:
+            runner.download_all_dependencies('requirements.txt', 'directory')
+        assert str(einfo.value) == ('Do not have permissions to write to '
+                                    '/foo/bar/baz.tar.gz.')
+
+
+class TestSdistMetadataFetcher(object):
+    _SETUPTOOLS = 'from setuptools import setup'
+    _DISTUTILS = 'from distutils.core import setup'
+    _BOTH = (
+        'try:\n'
+        '    from setuptools import setup\n'
+        'except ImportError:\n'
+        '    from distutils.core import setuptools\n'
+    )
+
+    _SETUP_PY = (
+        '%s\n'
+        'setup(\n'
+        '    name="%s",\n'
+        '    version="%s"\n'
+        ')\n'
+    )
+
+    def _write_fake_sdist(self, setup_py, directory, ext):
+        filename = 'sdist.%s' % ext
+        path = '%s/%s' % (directory, filename)
+        if ext == 'zip':
+            with zipfile.ZipFile(path, 'w',
+                                 compression=zipfile.ZIP_DEFLATED) as z:
+                z.writestr('sdist/setup.py', setup_py)
+        else:
+            with tarfile.open(path, 'w:gz') as tar:
+                tarinfo = tarfile.TarInfo('sdist/setup.py')
+                tarinfo.size = len(setup_py)
+                tar.addfile(tarinfo, io.BytesIO(setup_py.encode()))
+        return directory, filename
+
+    def test_setup_tar_gz(self, osutils, sdist_reader):
+        setup_py = self._SETUP_PY % (
+            self._SETUPTOOLS, 'foo', '1.0'
+        )
+        with osutils.tempdir() as tempdir:
+            directory, filename = self._write_fake_sdist(
+                setup_py, tempdir, 'tar.gz')
+            name, version = sdist_reader.get_package_name_and_version(
+                directory, filename)
+        assert name == 'foo'
+        assert version == '1.0'
+
+    def test_setup_tar_gz_hyphens_in_name(self, osutils, sdist_reader):
+        # The whole reason we need to use the egg info to get the name and
+        # version is that we cannot deterministically parse that information
+        # from the filenames themselves. This test puts hyphens in the name
+        # and version which would break a simple ``split("-")`` attempt to get
+        # that information.
+        setup_py = self._SETUP_PY % (
+            self._SETUPTOOLS, 'foo-bar', '1.0-2b'
+        )
+        with osutils.tempdir() as tempdir:
+            directory, filename = self._write_fake_sdist(
+                setup_py, tempdir, 'tar.gz')
+            name, version = sdist_reader.get_package_name_and_version(
+                directory, filename)
+        assert name == 'foo-bar'
+        assert version == '1.0-2b'
+
+    def test_setup_zip(self, osutils, sdist_reader):
+        setup_py = self._SETUP_PY % (
+            self._SETUPTOOLS, 'foo', '1.0'
+        )
+        with osutils.tempdir() as tempdir:
+            directory, filename = self._write_fake_sdist(
+                setup_py, tempdir, 'zip')
+            name, version = sdist_reader.get_package_name_and_version(
+                directory, filename)
+        assert name == 'foo'
+        assert version == '1.0'
+
+    def test_distutil_tar_gz(self, osutils, sdist_reader):
+        setup_py = self._SETUP_PY % (
+            self._DISTUTILS, 'foo', '1.0'
+        )
+        with osutils.tempdir() as tempdir:
+            directory, filename = self._write_fake_sdist(
+                setup_py, tempdir, 'tar.gz')
+            name, version = sdist_reader.get_package_name_and_version(
+                directory, filename)
+        assert name == 'foo'
+        assert version == '1.0'
+
+    def test_distutil_zip(self, osutils, sdist_reader):
+        setup_py = self._SETUP_PY % (
+            self._DISTUTILS, 'foo', '1.0'
+        )
+        with osutils.tempdir() as tempdir:
+            directory, filename = self._write_fake_sdist(
+                setup_py, tempdir, 'zip')
+            name, version = sdist_reader.get_package_name_and_version(
+                directory, filename)
+        assert name == 'foo'
+        assert version == '1.0'
+
+    def test_both_tar_gz(self, osutils, sdist_reader):
+        setup_py = self._SETUP_PY % (
+            self._BOTH, 'foo-bar', '1.0-2b'
+        )
+        with osutils.tempdir() as tempdir:
+            directory, filename = self._write_fake_sdist(
+                setup_py, tempdir, 'tar.gz')
+            name, version = sdist_reader.get_package_name_and_version(
+                directory, filename)
+        assert name == 'foo-bar'
+        assert version == '1.0-2b'
+
+    def test_both_zip(self, osutils, sdist_reader):
+        setup_py = self._SETUP_PY % (
+            self._BOTH, 'foo', '1.0'
+        )
+        with osutils.tempdir() as tempdir:
+            directory, filename = self._write_fake_sdist(
+                setup_py, tempdir, 'zip')
+            name, version = sdist_reader.get_package_name_and_version(
+                directory, filename)
+        assert name == 'foo'
+        assert version == '1.0'
+
+    def test_bad_format(self, osutils, sdist_reader):
+        setup_py = self._SETUP_PY % (
+            self._BOTH, 'foo', '1.0'
+        )
+        with osutils.tempdir() as tempdir:
+            directory, filename = self._write_fake_sdist(
+                setup_py, tempdir, 'tar.gz2')
+            with pytest.raises(InvalidSourceDistributionNameError):
+                name, version = sdist_reader.get_package_name_and_version(
+                    directory, filename)


### PR DESCRIPTION
The algorithm for building a lambda compatible bundle is as follows:

1) Download all packages using pip download without specifying binary
preference. This allows it to download whl files where possible and
sdists otherwise.
2) Try to download lamba-compatible whl files for all sdists
and lambda-incompatible whl files that were downloaded in the first
step. Once this step is completed we have all the whl files are are
going to be able to get from PyPi that are compatible with lambda.
3) Any sdists left over without a corresponding compatible whl file will
now be built to a whl. If this results in an incompatible whl file there
is nothing more we can do to get a compatible one and it is up to the
user to vendor that package themselves.

Now that we have done our best to get a whl file for each dependency, we
do a final pass over the directory and install all compatible whl files
to the lambda package. Any left over dependencies that do not have a
compatible whl file are reported to the user, as they will need to be
manually added to the vendor directory before deployment.

Virtualenv is no longer used so the compat functionality for it is no
longer needed.

Since the packaging process now downloads whl files which vary by python
version the deployment process now rebuilds the deployment package if it
detects that the python version has changed.


Old PR which stopped sycing with my fork branch for some reason: https://github.com/awslabs/chalice/pull/382

closes: #249 #227 #364 

cc @jamesls @kyleknap @dstufft 