### PR TITLE
Default lambda_functions key if it does not exist

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 CHANGELOG
 =========
 
+Next Release (TBD)
+==================
+
+* Fix deployment issue for projects deployed with versions
+  prior to 0.10.0
+  (`#387 <https://github.com/awslabs/chalice/issues/387>`__)
+
+
 0.10.0
 ======
 

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -320,5 +320,8 @@ class DeployedResources(object):
             data['api_gateway_stage'],
             data['region'],
             data['chalice_version'],
-            data['lambda_functions'],
+            # Versions prior to 0.10.0 did not have
+            # the 'lambda_functions' key, so we have
+            # to default this if it's missing.
+            data.get('lambda_functions', {}),
         )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -249,6 +249,22 @@ def test_can_create_deployed_resource_from_dict():
     assert d.lambda_functions == {}
 
 
+def test_lambda_functions_not_required_from_dict():
+    older_version = {
+        # Older versions of chalice did not include the
+        # lambda_functions key.
+        'backend': 'api',
+        'api_handler_arn': 'arn',
+        'api_handler_name': 'name',
+        'rest_api_id': 'id',
+        'api_gateway_stage': 'stage',
+        'region': 'region',
+        'chalice_version': '1.0.0',
+    }
+    d = DeployedResources.from_dict(older_version)
+    assert d.lambda_functions == {}
+
+
 def test_environment_from_top_level():
     config_from_disk = {'environment_variables': {"foo": "bar"}}
     c = Config('dev', config_from_disk=config_from_disk)


### PR DESCRIPTION
Fixes issue when deploying chalice apps prior to 0.10.0.
Closes #387.