### PR TITLE
Fix crash when analyzer encounters listcomp/genexprs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Next Release (TBD)
 * Fix deployment issue for projects deployed with versions
   prior to 0.10.0
   (`#387 <https://github.com/awslabs/chalice/issues/387>`__)
+* Fix crash in analyzer when encountering genexprs and listcomps
+  (`#263 <https://github.com/awslabs/chalice/issues/263>`__)
 
 
 0.10.0

--- a/tests/unit/test_analyzer.py
+++ b/tests/unit/test_analyzer.py
@@ -425,6 +425,39 @@ def test_dict_comp_with_no_client_calls():
     """) == {}
 
 
+def test_can_handle_gen_expr():
+    assert aws_calls("""\
+        import boto3
+        ('a' for y in [1,2,3])
+    """) == {}
+
+
+def test_can_detect_calls_in_gen_expr():
+    assert aws_calls("""\
+        import boto3
+        service_name = 'dynamodb'
+        d = boto3.client('dynamodb')
+        (d.list_tables() for i in [1,2,3])
+    """) == {'dynamodb': set(['list_tables'])}
+
+
+def test_can_detect_calls_in_multiple_gen_exprs():
+    assert aws_calls("""\
+        import boto3
+        d = boto3.client('dynamodb')
+        (d for i in [1,2,3])
+        (d.list_tables() for j in [1,2,3])
+    """) == {'dynamodb': set(['list_tables'])}
+
+
+def test_can_handle_list_expr_with_api_calls():
+    assert aws_calls("""\
+        import boto3
+        d = boto3.client('dynamodb')
+        [d.list_tables() for y in [1,2,3]]
+    """) == {'dynamodb': set(['list_tables'])}
+
+
 #def test_can_handle_dict_comp():
 #    assert aws_calls("""\
 #        import boto3


### PR DESCRIPTION
Internally, python creates a function for listcomps/genexprs
so we treat it similarly.  There's a new child scope and therefore
a new symbol table we need to fetch.  The only tricky part is that
python names this function 'genexpr' and 'listcomp' even in the
case of multiple genexprs and listcomps.  We're not analyzing the
`generators` attr of the nodes, but we will need to take that
into account when we do.  For now it doesn't matter.

Closes  #263 