### PR TITLE
Add support for scheduled events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,10 +3,12 @@ CHANGELOG
 =========
 
 Next Release (TBD)
-============
+==================
 
 * Fix unicode responses being quoted in python 2.7
   (`#262 <https://github.com/awslabs/chalice/issues/262>`__)
+* Add support for scheduled events
+  (`#390 <https://github.com/awslabs/chalice/issues/390>`__)
 
 
 0.10.1

--- a/chalice/__init__.py
+++ b/chalice/__init__.py
@@ -3,7 +3,7 @@ from chalice.app import (
     ChaliceViewError, BadRequestError, UnauthorizedError, ForbiddenError,
     NotFoundError, ConflictError, TooManyRequestsError, Response, CORSConfig,
     CustomAuthorizer, CognitoUserPoolAuthorizer, IAMAuthorizer,
-    AuthResponse, AuthRoute
+    AuthResponse, AuthRoute, Cron, Rate
 )
 
 __version__ = '0.10.1'

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -491,7 +491,7 @@ class Chalice(object):
                 execution_role=execution_role,
             )
             self.builtin_auth_handlers.append(auth_config)
-            return ChaliceAuthorizer(name, auth_func, auth_config)
+            return ChaliceAuthorizer(auth_name, auth_func, auth_config)
         return _register_authorizer
 
     def schedule(self, expression, name=None):
@@ -499,12 +499,12 @@ class Chalice(object):
             handler_name = name
             if handler_name is None:
                 handler_name = event_func.__name__
-            event_source = EventSource(
+            event_source = CloudWatchEventSource(
                 name=handler_name,
                 schedule_expression=expression,
                 handler_string='app.%s' % event_func.__name__)
             self.event_sources.append(event_source)
-            return ScheduluedEventHandler(event_func)
+            return ScheduledEventHandler(event_func)
         return _register_schedule
 
     def route(self, path, **kwargs):
@@ -792,10 +792,15 @@ class AuthRoute(object):
 
 
 class EventSource(object):
-    def __init__(self, name, schedule_expression, handler_string):
+    def __init__(self, name, handler_string):
         self.name = name
-        self.schedule_expression = schedule_expression
         self.handler_string = handler_string
+
+
+class CloudWatchEventSource(EventSource):
+    def __init__(self, name, handler_string, schedule_expression):
+        super(CloudWatchEventSource, self).__init__(name, handler_string)
+        self.schedule_expression = schedule_expression
 
 
 class ScheduleExpression(object):
@@ -841,7 +846,7 @@ class Cron(ScheduleExpression):
         )
 
 
-class ScheduluedEventHandler(object):
+class ScheduledEventHandler(object):
     def __init__(self, func):
         self.func = func
 

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -110,7 +110,7 @@ class Chalice(object):
     debug = ... # type: bool
     authorizers = ... # type: Dict[str, Dict[str, Any]]
     builtin_auth_handlers = ... # type: List[BuiltinAuthConfig]
-    event_sources = ... # type: List[EventSource]
+    event_sources = ... # type: List[CloudWatchEventSource]
 
     def __init__(self, app_name: str) -> None: ...
 
@@ -153,8 +153,11 @@ class AuthResponse(object):
 
 class EventSource(object):
     name = ...  # type: str
-    schedule_expression = ...  # type: Union[str, ScheduleExpression]
     handler_string = ...  # type: str
+
+
+class CloudWatchEventSource(EventSource):
+    schedule_expression = ...  # type: Union[str, ScheduleExpression]
 
 
 class ScheduleExpression(object):
@@ -162,7 +165,7 @@ class ScheduleExpression(object):
 
 
 class Rate(ScheduleExpression):
-    unit = ... # type: str
+    unit = ... # type: int
     value = ... # type: str
 
     def to_string(self) -> str: ...

--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -110,6 +110,7 @@ class Chalice(object):
     debug = ... # type: bool
     authorizers = ... # type: Dict[str, Dict[str, Any]]
     builtin_auth_handlers = ... # type: List[BuiltinAuthConfig]
+    event_sources = ... # type: List[EventSource]
 
     def __init__(self, app_name: str) -> None: ...
 
@@ -148,3 +149,31 @@ class AuthResponse(object):
     routes = ... # type: Union[str, AuthRoute]
     principal_id = ... # type: str
     context = ... # type: Optional[Dict[str, str]]
+
+
+class EventSource(object):
+    name = ...  # type: str
+    schedule_expression = ...  # type: Union[str, ScheduleExpression]
+    handler_string = ...  # type: str
+
+
+class ScheduleExpression(object):
+    def to_string(self) -> str: ...
+
+
+class Rate(ScheduleExpression):
+    unit = ... # type: str
+    value = ... # type: str
+
+    def to_string(self) -> str: ...
+
+
+class Cron(ScheduleExpression):
+    minutes = ... # type: Union[str, int]
+    hours = ... # type: Union[str, int]
+    day_of_month = ... # type: Union[str, int]
+    month = ... # type: Union[str, int]
+    day_of_week = ... # type: Union[str, int]
+    year = ... # type: Union[str, int]
+
+    def to_string(self) -> str: ...

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -308,6 +308,25 @@ class DeployedResources(object):
         self.region = region
         self.chalice_version = chalice_version
         self.lambda_functions = lambda_functions
+        self._fixup_lambda_functions_if_needed()
+
+    def _fixup_lambda_functions_if_needed(self):
+        # type: () -> None
+        # In version 0.10.0 of chalice, 'lambda_functions'
+        # was introduced where the value was just the string ARN.
+        # With the introduction of scheduled events, we need to
+        # be able to distinguish the purpose of the lambda function.
+        # To smooth this over, we'll convert the old format to the
+        # new one.  The deployer.py module will take care of writing out
+        # a new deployed.json in the correct format.
+        if all(isinstance(v, dict) for v in self.lambda_functions.values()):
+            return
+        for k, v in self.lambda_functions.items():
+            # In 0.10.0 the only type of lambda function we supported
+            # was custom authorizers so we can safely assume the type
+            # was authorizer.
+            self.lambda_functions[k] = {'type': 'authorizer',
+                                        'arn': v}
 
     @classmethod
     def from_dict(cls, data):

--- a/chalice/deploy/swagger.py
+++ b/chalice/deploy/swagger.py
@@ -73,7 +73,8 @@ class SwaggerGenerator(object):
                 self._deployed_resources['api_handler_name'],
                 authorizer.config.name
             )
-            arn = self._deployed_resources['lambda_functions'][function_name]
+            arn = self._deployed_resources[
+                'lambda_functions'][function_name]['arn']
             auth_config = authorizer.config
             config = {
                 'in': 'header',

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -65,6 +65,7 @@ Topics
    topics/pyversion
    topics/cfn
    topics/authorizers
+   topics/events
 
 
 API Reference

--- a/docs/source/topics/events.rst
+++ b/docs/source/topics/events.rst
@@ -1,0 +1,55 @@
+====================
+Lambda Event Sources
+====================
+
+
+Scheduled Events
+================
+
+Chalice has support for `scheduled events`_.  This feature allows you to
+periodically invoke a lambda function based on some regular schedule.  You can
+specify a fixed rate or a cron expression.
+
+To create a scheduled event in chalice, you use the ``@app.schedule()``
+decorator.  Let's look at an example.
+
+
+.. code-block:: python
+
+    app = chalice.Chalice(app_name='foo')
+
+    @app.schedule('rate(1 hour)')
+    def every_hour(event):
+        print(event.to_dict())
+
+    @app.route('/')
+    def index():
+        return {'hello': 'world'}
+
+
+In this example, we've updated the starter hello world app with
+a scheduled event.  When you run ``chalice deploy`` Chalice will create
+two Lambda functions.  The first lambda function is for the API handler
+used by API gateway.  The second lambda function will be for the scheduled
+CloudWatch event (the ``every_hour`` function).   The ``every_hour`` function
+will be automatically invoked every hour by Lambda.
+
+The :meth:`Chalice.schedule` method accepts either a string or an
+instance of :class:`Rate` or :class:`Cron`.  For example:
+
+.. code-block:: python
+
+    app = chalice.Chalice(app_name='foo')
+
+    @app.schedule(Rate(1, unit=Rate.HOURS))
+    def every_hour(event):
+        print(event.to_dict())
+
+
+The function you decorate must accept a single argument,
+which will be of type :class:`CloudWatchEvent`.
+
+Limitations:
+
+* You must provide at least 1 ``@app.route`` decorator.  It is not
+  possible to deploy only scheduled events without an API Gateway API.

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -904,49 +904,48 @@ class TestAddPermissionsForAPIGateway(object):
 
     def test_can_add_permission_for_apigateway_not_needed(self, stubbed_session):
         source_arn = 'arn:aws:execute-api:us-west-2:123:rest-api-id/*'
+        wrong_action = {
+            'Action': 'lambda:NotInvoke',
+            'Condition': {
+                'ArnLike': {
+                    'AWS:SourceArn': source_arn,
+                }
+            },
+            'Effect': 'Allow',
+            'Principal': {'Service': 'apigateway.amazonaws.com'},
+            'Resource': 'arn:aws:lambda:us-west-2:account_id:function:name',
+            'Sid': 'e4755709-067e-4254-b6ec-e7f9639e6f7b',
+        }
+        wrong_service_name = {
+            'Action': 'lambda:Invoke',
+            'Condition': {
+                'ArnLike': {
+                    'AWS:SourceArn': source_arn,
+                }
+            },
+            'Effect': 'Allow',
+            'Principal': {'Service': 'NOT-apigateway.amazonaws.com'},
+            'Resource': 'arn:aws:lambda:us-west-2:account_id:function:name',
+            'Sid': 'e4755709-067e-4254-b6ec-e7f9639e6f7b',
+        }
+        correct_statement = {
+            'Action': 'lambda:InvokeFunction',
+            'Condition': {
+                'ArnLike': {
+                    'AWS:SourceArn': source_arn,
+                }
+            },
+            'Effect': 'Allow',
+            'Principal': {'Service': 'apigateway.amazonaws.com'},
+            'Resource': 'arn:aws:lambda:us-west-2:account_id:function:name',
+            'Sid': 'e4755709-067e-4254-b6ec-e7f9639e6f7b',
+        }
         policy = {
             'Id': 'default',
             'Statement': [
-                {'Action': 'lambda:NotInvoke',
-                 'Condition': {
-                     'ArnLike': {
-                         'AWS:SourceArn': source_arn,
-                     }
-                 },
-                 'Effect': 'Allow',
-                 'Principal': {'Service': 'apigateway.amazonaws.com'},
-                 'Resource': 'arn:aws:lambda:us-west-2:account_id:function:name',
-                 'Sid': 'e4755709-067e-4254-b6ec-e7f9639e6f7b'},
-                {'Action': 'lambda:InvokeFunction',
-                 'Condition': {
-                     'ArnLike': {
-                         'AWS:SourceArn': 'not-source-arn',
-                     }
-                 },
-                 'Effect': 'Allow',
-                 'Principal': {'Service': 'apigateway.amazonaws.com'},
-                 'Resource': 'arn:aws:lambda:us-west-2:account_id:function:name',
-                 'Sid': 'e4755709-067e-4254-b6ec-e7f9639e6f7b'},
-                {'Action': 'lambda:InvokeFunction',
-                 'Condition': {
-                     'ArnLike': {
-                         'AWS:SourceArn': source_arn,
-                     }
-                 },
-                 'Effect': 'Allow',
-                 'Principal': {'Service': 'NOT-apigateway.amazonaws.com'},
-                 'Resource': 'arn:aws:lambda:us-west-2:account_id:function:name',
-                 'Sid': 'e4755709-067e-4254-b6ec-e7f9639e6f7b'},
-                {'Action': 'lambda:InvokeFunction',
-                 'Condition': {
-                     'ArnLike': {
-                         'AWS:SourceArn': source_arn,
-                     }
-                 },
-                 'Effect': 'Allow',
-                 'Principal': {'Service': 'apigateway.amazonaws.com'},
-                 'Resource': 'arn:aws:lambda:us-west-2:account_id:function:name',
-                 'Sid': 'e4755709-067e-4254-b6ec-e7f9639e6f7b'},
+                wrong_action,
+                wrong_service_name,
+                correct_statement,
             ],
             'Version': '2012-10-17'
         }

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1014,3 +1014,126 @@ def test_special_cased_root_resource(auth_request):
             'Resource': expected,
         }]
     }
+
+
+def test_can_register_scheduled_event_with_str(sample_app):
+    @sample_app.schedule('rate(1 minute)')
+    def foo(event):
+        pass
+
+    assert len(sample_app.event_sources) == 1
+    event_source = sample_app.event_sources[0]
+    assert event_source.name == 'foo'
+    assert event_source.schedule_expression == 'rate(1 minute)'
+    assert event_source.handler_string == 'app.foo'
+
+
+def test_can_register_scheduled_event_with_rate(sample_app):
+    @sample_app.schedule(app.Rate(value=2, unit=app.Rate.HOURS))
+    def foo(event):
+        pass
+
+    # We don't convert the rate down to its string form until
+    # we actually deploy.
+    assert len(sample_app.event_sources) == 1
+    expression = sample_app.event_sources[0].schedule_expression
+    # We already check the event source in the test above, so we're
+    # only interested in the schedule expression here.
+    assert expression.value == 2
+    assert expression.unit == app.Rate.HOURS
+
+
+def test_can_register_scheduled_event_with_event(sample_app):
+    @sample_app.schedule(app.Cron(0, 10, '*', '*', '?', '*'))
+    def foo(event):
+        pass
+
+    assert len(sample_app.event_sources) == 1
+    expression = sample_app.event_sources[0].schedule_expression
+    assert expression.minutes == 0
+    assert expression.hours == 10
+    assert expression.day_of_month == '*'
+    assert expression.month == '*'
+    assert expression.day_of_week == '?'
+    assert expression.year == '*'
+
+
+@pytest.mark.parametrize('value,unit,expected', [
+    (1, app.Rate.MINUTES, 'rate(1 minute)'),
+    (2, app.Rate.MINUTES, 'rate(2 minutes)'),
+    (1, app.Rate.HOURS, 'rate(1 hour)'),
+    (2, app.Rate.HOURS, 'rate(2 hours)'),
+    (1, app.Rate.DAYS, 'rate(1 day)'),
+    (2, app.Rate.DAYS, 'rate(2 days)'),
+])
+def test_rule_object_converts_to_str(value, unit, expected):
+    assert app.Rate(value=value, unit=unit).to_string() == expected
+
+
+@pytest.mark.parametrize('minutes,hours,day_of_month,month,day_of_week,year,expected', [
+    # These are taken from the scheduled events docs page.
+    # Invoke a Lambda function at 10:00am (UTC) everyday
+    (0, 10, '*', '*', '?', '*', 'cron(0 10 * * ? *)'),
+    # Invoke a Lambda function 12:15pm (UTC) everyday
+    (15, 12, '*', '*', '?', '*', 'cron(15 12 * * ? *)'),
+    # Invoke a Lambda function at 06:00pm (UTC) every Mon-Fri
+    (0, 18, '?', '*', 'MON-FRI', '*', 'cron(0 18 ? * MON-FRI *)'),
+    # Invoke a Lambda function at 8:00am (UTC) every first day of the month
+    (0, 8, 1, '*', '?', '*', 'cron(0 8 1 * ? *)'),
+    # Invoke a Lambda function every 10 min Mon-Fri
+    ('0/10', '*', '?', '*', 'MON-FRI', '*', 'cron(0/10 * ? * MON-FRI *)'),
+    # Invoke a Lambda function every 5 minutes Mon-Fri between 8:00am and
+    # 5:55pm (UTC)
+    ('0/5', '8-17', '?', '*', 'MON-FRI', '*', 'cron(0/5 8-17 ? * MON-FRI *)'),
+    # Invoke a Lambda function at 9 a.m. (UTC) the first Monday of each month
+    (0, 9, '?', '*', '2#1', '*', 'cron(0 9 ? * 2#1 *)'),
+])
+def test_cron_expression_converts_to_str(minutes, hours, day_of_month, month,
+                                         day_of_week, year, expected):
+    assert app.Cron(
+        minutes=minutes,
+        hours=hours,
+        day_of_month=day_of_month,
+        month=month,
+        day_of_week=day_of_week,
+        year=year,
+    ).to_string() == expected
+
+
+def test_can_map_event_dict_to_object(sample_app):
+
+    @sample_app.schedule('rate(1 hour)')
+    def handler(event):
+        return event
+
+    # This is the event dict that lambda provides
+    # to the lambda handler
+    lambda_event = {
+        "version": "0",
+        "account": "123456789012",
+        "region": "us-west-2",
+        "detail": {},
+        "detail-type": "Scheduled Event",
+        "source": "aws.events",
+        "time": "1970-01-01T00:00:00Z",
+        "id": "event-id",
+        "resources": [
+          "arn:aws:events:us-west-2:123456789012:rule/my-schedule"
+        ]
+    }
+
+    event_object = handler(lambda_event, context=None)
+    assert event_object.version == '0'
+    assert event_object.event_id == 'event-id'
+    assert event_object.source == 'aws.events'
+    assert event_object.account == '123456789012'
+    assert event_object.time == '1970-01-01T00:00:00Z'
+    assert event_object.region == 'us-west-2'
+    assert event_object.resources == [
+        "arn:aws:events:us-west-2:123456789012:rule/my-schedule"
+    ]
+    assert event_object.detail == {}
+    assert event_object.detail_type == "Scheduled Event"
+    # This is meant as a fall back in case you need access to
+    # the raw lambda event dict.
+    assert event_object.to_dict() == lambda_event

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -810,6 +810,7 @@ def test_can_handle_builtin_auth():
     assert isinstance(authorizer, app.BuiltinAuthConfig)
     assert authorizer.name == 'my_auth'
     assert authorizer.handler_string == 'app.my_auth'
+    assert my_auth.name == 'my_auth'
 
 
 def test_builtin_auth_can_transform_event():


### PR DESCRIPTION
Proposal: https://github.com/awslabs/chalice/issues/390

Sample app:

```python
from chalice import Chalice
import datetime

app = Chalice(app_name='testevents')


@app.route('/')
def index():
    return {'hello': 'world'}


@app.schedule('rate(1 minute)')
def every_minute(event):
    print(event.to_dict())

```


The implementation piggy backs off of the multi lambda support from the built in authorizers.  The only unexpected change was an update to the deployed.json file from:

```
    "lambda_functions": {
      "testevents-dev-every_minute": "arn:lambda-foo"
    },

```
to:

```
    "lambda_functions": {
      "testevents-dev-every_minute": {
        "type": "scheduled_event",
        "arn": "arn:lambda-foo"
      }
    },

```

So we can differentiate the different types of lambda functions.

The other caveat is that right now you still need to deploy an API gateway API.  There isn't support yet for only deploying scheduled events.  That will be in a follow up PR.

**Review Notes**

The deployer module has some duplication that I'm working on removing.  The logic itself won't change but I'm refactoring the code.  Everything else (`app.py`, `awsclient.py`, all the tests) are ready for review.