### PR TITLE
Fix unicode strings being quoted in python 2.7.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 CHANGELOG
 =========
 
+Next Release (TBD)
+============
+
+* Fix unicode responses being quoted in python 2.7
+  (`#262 <https://github.com/awslabs/chalice/issues/262>`__)
+
+
 0.10.1
 ======
 

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -17,6 +17,16 @@ from collections import defaultdict, Mapping
 
 _PARAMS = re.compile(r'{\w+}')
 
+try:
+    # In python 2 there is a base class for the string types that
+    # we can check for. It was removed in python 3 so it will cause
+    # a name error.
+    _ANY_STRING = (basestring, bytes)
+except NameError:
+    # In python 3 string and bytes are different so we explicitly check
+    # for both.
+    _ANY_STRING = (str, bytes)
+
 
 def handle_decimals(obj):
     # Lambda will automatically serialize decimals so we need
@@ -299,7 +309,7 @@ class Response(object):
 
     def to_dict(self, binary_types=None):
         body = self.body
-        if not isinstance(body, (str, bytes)):
+        if not isinstance(body, _ANY_STRING):
             body = json.dumps(body, default=handle_decimals)
         response = {
             'headers': self.headers,

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -111,6 +111,16 @@ def test_can_encode_binary_body_as_base64(sample_app):
     assert encoded_response['body'] == 'Zm9vYmFy'
 
 
+def test_can_return_unicode_body(sample_app):
+    unicode_data = u'\u2713'
+    response = app.Response(
+        status_code=200,
+        body=unicode_data
+    )
+    encoded_response = response.to_dict()
+    assert encoded_response['body'] == unicode_data
+
+
 def test_can_encode_binary_body_with_header_charset(sample_app):
     response = app.Response(
         status_code=200,


### PR DESCRIPTION
Not sure how exactly we want to do the compat layer. Still have no explicit checks against python version.

fixes #262 

cc @jamesls @kyleknap  @dstufft @JordonPhillips 