### PR TITLE
ISSUE-396 enhances local to utilize environment_variables from config.json

### DIFF
--- a/docs/source/topics/configfile.rst
+++ b/docs/source/topics/configfile.rst
@@ -78,7 +78,7 @@ be checked.
 
 * ``environment_variables`` - A mapping of key value pairs.  These
   key value pairs will be set as environment variables in your
-  deployed application.  All environment variables must be strings.
+  application.  All environment variables must be strings.
   If this key is specified in both a stage specific config option
   as well as a top level key, the stage specific environment
   variables will be merged into the top level keys.  See the

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,7 @@
+from chalice import cli
+
+
+def test_get_env_variables():
+    config = {'environment_variables': {'test': 'true'}}
+    env_variables = cli.get_env_variables(config)
+    assert env_variables == config['environment_variables']

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -1,7 +1,6 @@
 import json
 import decimal
 import pytest
-import mock
 import os
 from pytest import fixture
 from six import BytesIO
@@ -9,7 +8,6 @@ from six import BytesIO
 from chalice import app
 from chalice import local, BadRequestError, CORSConfig
 from chalice import Response
-from chalice.cli import factory
 
 
 class ChaliceStubbedHandler(local.ChaliceRequestHandler):
@@ -23,7 +21,6 @@ class ChaliceStubbedHandler(local.ChaliceRequestHandler):
 
     def finish(self):
         pass
-
 
 @fixture
 def sample_app():
@@ -373,13 +370,15 @@ def test_can_create_lambda_event_for_post_with_formencoded_body():
         'stageVariables': {},
     }
 
+
 def test_can_provide_port_to_local_server(sample_app):
-    with mock.patch.object(factory.CLIFactory, 'load_project_config', return_value={}):
-        dev_server = local.create_local_server(sample_app, port=23456)
-        assert dev_server.server.server_port == 23456
+    dev_server = local.create_local_server(sample_app, port=23456)
+    assert dev_server.server.server_port == 23456
+
 
 def test_environment_variables_set(sample_app):
-    with mock.patch.object(factory.CLIFactory, 'load_project_config', return_value={'environment_variables': {'test': True}}):
-        local.create_local_server(sample_app, port=23456)
-        assert os.environ['test'] == 'True'
+    env_variables = {'test': True}
+    local.create_local_server(sample_app, port=23456,
+                              env_variables=env_variables)
+    assert os.environ['test'] == 'True'
 


### PR DESCRIPTION
Issue for this PR:
https://github.com/awslabs/chalice/issues/396

Running `chalice local` with environment variables set inside of `config.json` now works as expected:
```
(venv-chalice) Braverman@local:~/Repos/fix-local-env-vars $ http localhost:8000
HTTP/1.0 200 OK
Content-Length: 78
Content-Type: application/json
Date: Tue, 04 Jul 2017 17:42:01 GMT
Server: BaseHTTP/0.3 Python/2.7.10

{
    "env_vars": {
        "py": "con", 
        "rick": "Morty", 
        "test": "True"
    }, 
    "hello": "world"
}

```