### PR TITLE
Add support for pure lambda functions

### DIFF
--- a/chalice/app.pyi
+++ b/chalice/app.pyi
@@ -111,6 +111,7 @@ class Chalice(object):
     authorizers = ... # type: Dict[str, Dict[str, Any]]
     builtin_auth_handlers = ... # type: List[BuiltinAuthConfig]
     event_sources = ... # type: List[CloudWatchEventSource]
+    pure_lambda_functions = ... # type: List[LambdaFunction]
 
     def __init__(self, app_name: str) -> None: ...
 
@@ -180,3 +181,9 @@ class Cron(ScheduleExpression):
     year = ... # type: Union[str, int]
 
     def to_string(self) -> str: ...
+
+
+class LambdaFunction(object):
+    name = ... # type: str
+    handler_string = ... # type: str
+    func = ... # type: Callable[..., Any]

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -16,6 +16,7 @@ import botocore.session  # noqa
 from botocore.vendored.requests import ConnectionError as \
     RequestsConnectionError
 from typing import Any, Tuple, Callable, List, Dict, Optional  # noqa
+from typing import Set, Iterator  # noqa
 
 from chalice import app  # noqa
 from chalice.app import CloudWatchEventSource  # noqa
@@ -187,7 +188,7 @@ def _validate_manage_iam_role(config):
 
 def validate_unique_function_names(config):
     # type: (Config) -> None
-    names = set()
+    names = set()   # type: Set[str]
     for name in _get_all_function_names(config.chalice_app):
         if name in names:
             raise ValueError("Duplicate function name detected: %s\n"

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -421,10 +421,24 @@ class LambdaDeployer(object):
                                    deployed_values)
         self._deploy_event_sources(config, existing_resources, stage_name,
                                    deployed_values)
+        self._deploy_pure_lambda_functions(config, existing_resources,
+                                           stage_name, deployed_values)
         if existing_resources is not None:
             self._cleanup_unreferenced_functions(existing_resources,
                                                  deployed_values)
         return deployed_values
+
+    def _deploy_pure_lambda_functions(self, config, existing_resources,
+                                      stage_name, deployed_values):
+        # type: (Config, OPT_RESOURCES, str, Dict[str, Any]) -> None
+        for lambda_function in config.chalice_app.pure_lambda_functions:
+            new_config = config.scope(chalice_stage=config.chalice_stage,
+                                      function_name=lambda_function.name)
+            self._deploy_single_lambda_function(
+                new_config, lambda_function.name,
+                lambda_function.handler_string,
+                stage_name, deployed_values, 'pure_lambda'
+            )
 
     def _cleanup_unreferenced_functions(self, existing_resources,
                                         deployed_values):

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -159,6 +159,18 @@ Chalice
         entire lambda function name.  This parameter is optional.  If it is
         not provided, the name of the python function will be used.
 
+   .. method:: lambda_function(name=None)
+
+      Create a pure lambda function that's not connected to anything.
+
+      See :doc:`purelambda` for more information.
+
+      :param name: The name of the function to use.  This name is combined
+        with the chalice app name as well as the stage name to create the
+        entire lambda function name.  This parameter is optional.  If it is
+        not provided, the name of the python function will be used.
+
+
 Request
 =======
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -66,6 +66,7 @@ Topics
    topics/cfn
    topics/authorizers
    topics/events
+   topics/purelambda
 
 
 API Reference

--- a/docs/source/topics/purelambda.rst
+++ b/docs/source/topics/purelambda.rst
@@ -1,0 +1,62 @@
+=====================
+Pure Lambda Functions
+=====================
+
+
+Chalice provides abstractions over AWS Lambda functions, including:
+
+* An API handler the coordinates with API Gateway for creating rest APIs.
+* A custom authorizer that allows you to integrate custom auth logic in your
+  rest API.
+* A scheduled event that includes managing the CloudWatch Event rules, targets,
+  and permissions.
+
+However, chalice also supports managing pure Lambda functions that don't have
+any abstractions built on top.  This is useful if you want to create a Lambda
+function for something that's not supported by chalice or if you just want to
+create Lambda functions but don't want to manage handling dependencies and
+deployments yourself.
+
+In order to do this, you can use the :ref:`Chalice.lambda_function` decorator
+to denote that this python function is a pure lambda function that should
+be invoked as is, without any input or output mapping.  When you use
+this function, you must provide a function that maps to the same function
+signature expected by AWS Lambda as `defined here`_.
+
+Let's look at an example.
+
+.. code-block:: python
+
+    app = chalice.Chalice(app_name='foo')
+
+    @app.lambda_function()
+    def custom_lambda_function(event, context):
+        # Anything you want here.
+        return {}
+
+    @app.lambda_function(name='MyFunction')
+    def other_lambda_function(event, context):
+        # Anything you want here.
+        return {}
+
+    @app.route('/')
+    def index():
+        return {'hello': 'world'}
+
+
+In this example, we've updated the starter hello world app with
+two extra Lambda functions.  When you run ``chalice deploy`` Chalice will create
+three Lambda functions.  The first lambda function is for the API handler
+used by API gateway.  The second and third lambda function will be pure lambda
+functions.  These two additional lambda functions won't be hooked up to anything.
+You'll need to manage connecting them to any additional AWS Resources on your
+own.
+
+
+Limitations:
+
+* You must provide at least 1 ``@app.route`` decorator.  It is not
+  possible to deploy only lambda functions without an API Gateway API.
+
+
+.. _defined here: http://docs.aws.amazon.com/lambda/latest/dg/python-programming-model-handler-types.html

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -357,8 +357,8 @@ def test_validate_unique_lambda_function_names(sample_app):
 
     # This will cause a validation error because
     # 'foo' is already registered as a lambda function.
-    @sample_app.lambda_function()
-    def foo(event, context):
+    @sample_app.lambda_function(name='foo')
+    def bar(event, context):
         pass
 
     config = Config.create(chalice_app=sample_app, manage_iam_role=False)
@@ -372,7 +372,7 @@ def test_validate_names_across_function_types(sample_app):
         pass
 
     @sample_app.schedule('rate(1 hour)')
-    def foo(event):
+    def bar(event):
         pass
 
     config = Config.create(chalice_app=sample_app, manage_iam_role=False)
@@ -385,8 +385,8 @@ def test_validate_names_using_name_kwarg(sample_app):
     def foo(auth_request):
         pass
 
-    @sample_app.lambda_function()
-    def duplicate(event):
+    @sample_app.lambda_function(name='duplicate')
+    def bar(event):
         pass
 
     config = Config.create(chalice_app=sample_app, manage_iam_role=False)

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -371,7 +371,7 @@ def test_validate_names_across_function_types(sample_app):
     def foo(event, context):
         pass
 
-    @sample_app.schedule('rate(1 hour)')
+    @sample_app.schedule('rate(1 hour)', name='foo')
     def bar(event):
         pass
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1138,3 +1138,24 @@ def test_can_map_event_dict_to_object(sample_app):
     # This is meant as a fall back in case you need access to
     # the raw lambda event dict.
     assert event_object.to_dict() == lambda_event
+
+
+def test_pure_lambda_function_direct_mapping(sample_app):
+    @sample_app.lambda_function()
+    def handler(event, context):
+        return event, context
+
+    return_value = handler({'fake': 'event'}, {'fake': 'context'})
+    assert return_value[0] == {'fake': 'event'}
+    assert return_value[1] == {'fake': 'context'}
+
+
+def test_pure_lambda_functions_are_registered_in_app(sample_app):
+    @sample_app.lambda_function()
+    def handler(event, context):
+        pass
+
+    assert len(sample_app.pure_lambda_functions) == 1
+    lambda_function = sample_app.pure_lambda_functions[0]
+    assert lambda_function.name == 'handler'
+    assert lambda_function.handler_string == 'app.handler'


### PR DESCRIPTION
Proposal: https://github.com/awslabs/chalice/issues/400

Sample code:

```python
from chalice import Chalice

app = Chalice(app_name='testpurelambda')

@app.lambda_function()
def foo(event, context):
    return {"name": "foo"}


@app.lambda_function()
def bar(event, context):
    return {"name": "bar"}


@app.route('/')
def index():
    return {'hello': 'world'}
```

This will create 3 lambda functions:

```
 $ aws lambda list-functions --query "Functions[?starts_with(FunctionName, 'testpurelambda')].FunctionName"
[
    "testpurelambda-dev-foo",
    "testpurelambda-dev-bar",
    "testpurelambda-dev"
]
```