### PR TITLE
Clean up tests and improve test linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,6 @@ check:
 	# No unused imports, no undefined vars,
 	flake8 --ignore=E731,W503 --exclude chalice/__init__.py,chalice/compat.py --max-complexity 10 chalice/
 	flake8 --ignore=E731,W503,F401 --max-complexity 10 chalice/compat.py
-	#
-	#
-	# Basic error checking in test code
 	flake8 tests/unit/ tests/functional/
 	##### DOC8 ######
 	# Correct rst formatting for documentation
@@ -24,21 +21,9 @@ check:
 	#
 	#
 	pydocstyle --add-ignore=D100,D101,D102,D103,D104,D105,D204,D301 chalice/
-	#
-	#
-	#
-	###### PYLINT ERRORS ONLY ######
-	#
-	#
-	#
-	pylint --rcfile .pylintrc chalice
 
 pylint:
 	###### PYLINT ######
-	# Python linter.  This will generally not have clean output.
-	# So you'll need to manually verify this output.
-	#
-	#
 	pylint --rcfile .pylintrc chalice
 	# Run our custom linter on test code.
 	pylint --load-plugins tests.linter --disable=I,E,W,R,C,F --enable C9999 tests/
@@ -60,4 +45,4 @@ htmlcov:
 	rm -rf /tmp/htmlcov && mv htmlcov /tmp/
 	open /tmp/htmlcov/index.html
 
-prcheck: check typecheck test
+prcheck: check pylint typecheck test

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ pylint:
 	###### PYLINT ######
 	pylint --rcfile .pylintrc chalice
 	# Run our custom linter on test code.
-	pylint --load-plugins tests.linter --disable=I,E,W,R,C,F --enable C9999 tests/
+	pylint --load-plugins tests.linter --disable=I,E,W,R,C,F --enable C9999,C9998 tests/
 
 test:
 	py.test -v $(TESTS)

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ pylint:
 	#
 	#
 	pylint --rcfile .pylintrc chalice
+	# Run our custom linter on test code.
+	pylint --load-plugins tests.linter --disable=I,E,W,R,C,F --enable C9999 tests/
 
 test:
 	py.test -v $(TESTS)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ check:
 	#
 	#
 	# Basic error checking in test code
-	pyflakes tests/unit/ tests/functional/
+	flake8 tests/unit/ tests/functional/
 	##### DOC8 ######
 	# Correct rst formatting for documentation
 	#

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -97,4 +97,4 @@ def test_remove_stage_from_deployed_values_no_file(tmpdir):
     utils.remove_stage_from_deployed_values('fake_key', filename)
 
     # Make sure it doesn't create the file if it didn't already exist
-    assert os.path.isfile(filename) == False
+    assert not os.path.isfile(filename)

--- a/tests/linter.py
+++ b/tests/linter.py
@@ -1,0 +1,28 @@
+from pylint.checkers import BaseChecker
+from pylint.interfaces import IAstroidChecker
+from astroid.exceptions import InferenceError
+
+
+def register(linter):
+    linter.register_checker(PatchChecker(linter))
+
+
+class PatchChecker(BaseChecker):
+    __implements__ = (IAstroidChecker,)
+    name = 'patching-banned'
+    msgs = {
+        'C9999': ('Use of mock.patch is not allowed',
+                  'patch-call',
+                  'Use of mock.patch not allowed')
+    }
+    patch_pytype = 'mock.mock._patch'
+
+    def visit_call(self, node):
+        try:
+            for inferred_type in node.infer():
+                if inferred_type.pytype() == self.patch_pytype:
+                    self.add_message('patch-call', node=node)
+        except InferenceError:
+            # It's ok if we can't work out what type the function
+            # call is.
+            pass

--- a/tests/linter.py
+++ b/tests/linter.py
@@ -5,6 +5,7 @@ from astroid.exceptions import InferenceError
 
 def register(linter):
     linter.register_checker(PatchChecker(linter))
+    linter.register_checker(MocksUseSpecArg(linter))
 
 
 class PatchChecker(BaseChecker):
@@ -26,3 +27,31 @@ class PatchChecker(BaseChecker):
             # It's ok if we can't work out what type the function
             # call is.
             pass
+
+
+class MocksUseSpecArg(BaseChecker):
+    __implements__ = (IAstroidChecker,)
+    name = 'mocks-use-spec'
+    msgs = {
+        'C9998': ('mock.Mock() must provide "spec=" argument',
+                  'mock-missing-spec',
+                  'mock.Mock() must provide "spec=" argument')
+    }
+    mock_pytype = 'mock.mock.Mock'
+    required_kwarg = 'spec'
+
+    def visit_call(self, node):
+        try:
+            for inferred_type in node.infer():
+                if inferred_type.pytype() == self.mock_pytype:
+                    self._verify_spec_arg_provided(node)
+        except InferenceError:
+            pass
+
+    def _verify_spec_arg_provided(self, node):
+        if not node.keywords:
+            self.add_message('mock-missing-spec', node=node)
+            return
+        kwargs = [kwarg.arg for kwarg in node.keywords]
+        if self.required_kwarg not in kwargs:
+            self.add_message('mock-missing-spec', node=node)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -27,7 +27,6 @@ def sample_app_with_auth():
     def myauth(auth_request):
         pass
 
-
     @app.route('/', authorizer=myauth)
     def foo():
         return {}

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -906,7 +906,7 @@ def test_lambda_deployer_initial_deploy(app_policy, sample_app):
     osutils = InMemoryOSUtils({'packages.zip': b'package contents'})
     aws_client = mock.Mock(spec=TypedAWSClient)
     aws_client.create_function.return_value = 'lambda-arn'
-    packager = mock.Mock(LambdaDeploymentPackager)
+    packager = mock.Mock(spec=LambdaDeploymentPackager)
     packager.create_deployment_package.return_value = 'packages.zip'
     cfg = Config.create(
         chalice_stage='dev',
@@ -1118,7 +1118,7 @@ class TestLambdaInitialDeploymentWithConfigurations(object):
         self.aws_client.get_function_configuration.return_value = {
             'Runtime': 'FakePythonVersion'
         }
-        self.packager = mock.Mock(LambdaDeploymentPackager)
+        self.packager = mock.Mock(spec=LambdaDeploymentPackager)
         self.packager.create_deployment_package.return_value =\
             self.package_name
         self.packager.deployment_package_filename.return_value =\
@@ -1522,7 +1522,7 @@ class TestLambdaUpdateDeploymentWithConfigurations(object):
         self.prompter = mock.Mock(spec=NoPrompt)
         self.prompter.confirm.return_value = True
 
-        self.packager = mock.Mock(LambdaDeploymentPackager)
+        self.packager = mock.Mock(spec=LambdaDeploymentPackager)
         self.packager.create_deployment_package.return_value =\
             self.package_name
 

--- a/tests/unit/deploy/test_swagger.py
+++ b/tests/unit/deploy/test_swagger.py
@@ -98,6 +98,7 @@ def test_can_use_same_route_with_diff_http_methods(sample_app, swagger_gen):
     assert 'post' in view_config
     assert view_config['get'] == view_config['post']
 
+
 class TestPreflightCORS(object):
     def get_access_control_methods(self, view_config):
         return view_config['options'][
@@ -264,6 +265,7 @@ class TestPreflightCORS(object):
         # for CORS.
         assert allow_methods == "'GET,OPTIONS'"
 
+
 def test_can_add_api_key(sample_app, swagger_gen):
     @sample_app.route('/api-key-required', api_key_required=True)
     def foo(name):
@@ -288,6 +290,7 @@ def test_can_add_api_key(sample_app, swagger_gen):
 def test_can_use_authorizer_object(sample_app, swagger_gen):
     authorizer = CustomAuthorizer(
         'MyAuth', authorizer_uri='auth-uri', header='Authorization')
+
     @sample_app.route('/auth', authorizer=authorizer)
     def auth():
         return {'foo': 'bar'}
@@ -309,8 +312,10 @@ def test_can_use_authorizer_object(sample_app, swagger_gen):
         }
     }
 
+
 def test_can_use_iam_authorizer_object(sample_app, swagger_gen):
     authorizer = IAMAuthorizer()
+
     @sample_app.route('/auth', authorizer=authorizer)
     def auth():
         return {'foo': 'bar'}
@@ -327,10 +332,12 @@ def test_can_use_iam_authorizer_object(sample_app, swagger_gen):
           "x-amazon-apigateway-authtype": "awsSigv4"
     }
 
+
 def test_can_use_cognito_auth_object(sample_app, swagger_gen):
     authorizer = CognitoUserPoolAuthorizer('MyUserPool',
                                            header='Authorization',
                                            provider_arns=['myarn'])
+
     @sample_app.route('/api-key-required', authorizer=authorizer)
     def foo():
         return {}
@@ -355,6 +362,7 @@ def test_auth_defined_for_multiple_methods(sample_app, swagger_gen):
     authorizer = CognitoUserPoolAuthorizer('MyUserPool',
                                            header='Authorization',
                                            provider_arns=['myarn'])
+
     @sample_app.route('/pool1', authorizer=authorizer)
     def foo():
         return {}

--- a/tests/unit/test_analyzer.py
+++ b/tests/unit/test_analyzer.py
@@ -191,8 +191,7 @@ def test_multiple_services():
         asdf.get_object(Bucket='foo', Key='bar')
         d.create_table(TableName='foobar')
     """) == {'dynamodb': set(['list_tables', 'create_table']),
-             's3': set(['get_object']),
-    }
+             's3': set(['get_object'])}
 
 
 def test_basic_aliasing():
@@ -458,73 +457,73 @@ def test_can_handle_list_expr_with_api_calls():
     """) == {'dynamodb': set(['list_tables'])}
 
 
-#def test_can_handle_dict_comp():
-#    assert aws_calls("""\
-#        import boto3
-#        ddb = boto3.client('dynamodb')
-#        tables = {t: t for t in ddb.list_tables()}
-#    """) == {'dynamodb': set(['list_tables'])}
-#
-#
-#def test_tuple_assignment():
-#    assert aws_calls("""\
-#        import boto3
-#        import some_other_thing
-#        a, d = (1, boto3.client('dynamodb'))
-#        d.list_tables()
-#        d.create_table()
-#    """) == {'dynamodb': set(['list_tables'])}
-#
-#
-#def test_multiple_client_assignment():
-#    assert aws_calls("""\
-#        import boto3
-#        import some_other_thing
-#        s3, db = (boto3.client('s3'), boto3.client('dynamodb'))
-#        db.list_tables()
-#        s3.get_object(Bucket='a', Key='b')
-#    """) == {'dynamodb': set(['list_tables'])
+# def test_can_handle_dict_comp():
+#     assert aws_calls("""\
+#         import boto3
+#         ddb = boto3.client('dynamodb')
+#         tables = {t: t for t in ddb.list_tables()}
+#     """) == {'dynamodb': set(['list_tables'])}
+
+
+# def test_tuple_assignment():
+#     assert aws_calls("""\
+#         import boto3
+#         import some_other_thing
+#         a, d = (1, boto3.client('dynamodb'))
+#         d.list_tables()
+#         d.create_table()
+#     """) == {'dynamodb': set(['list_tables'])}
+
+
+# def test_multiple_client_assignment():
+#     assert aws_calls("""\
+#         import boto3
+#         import some_other_thing
+#         s3, db = (boto3.client('s3'), boto3.client('dynamodb'))
+#         db.list_tables()
+#         s3.get_object(Bucket='a', Key='b')
+#     """) == {'dynamodb': set(['list_tables'])
 #             's3': set(['get_object'])}
+
+
+# def test_understands_instance_methods():
+#     assert aws_calls("""\
+#         import boto3, mock
+#         class Foo(object):
+#             def make_call(self, client):
+#                 return client.list_tables()
 #
+#         d = boto3.client('dynamodb')
+#         instance = Foo()
+#         instance.make_call(d)
+#     """) == {'dynamodb': set(['list_tables'])}
+
+
+# def test_understands_function_and_methods():
+#     assert aws_calls("""\
+#         import boto3, mock
+#         class Foo(object):
+#             def make_call(self, client):
+#                 return foo_call(1, client)
 #
-#def test_understands_instance_methods():
-#    assert aws_calls("""\
-#        import boto3, mock
-#        class Foo(object):
-#            def make_call(self, client):
-#                return client.list_tables()
+#         def foo_call(a, client):
+#             return client.list_tables()
 #
-#        d = boto3.client('dynamodb')
-#        instance = Foo()
-#        instance.make_call(d)
-#    """) == {'dynamodb': set(['list_tables'])}
-#
-#
-#def test_understands_function_and_methods():
-#    assert aws_calls("""\
-#        import boto3, mock
-#        class Foo(object):
-#            def make_call(self, client):
-#                return foo_call(1, client)
-#
-#        def foo_call(a, client):
-#            return client.list_tables()
-#
-#        d = boto3.client('dynamodb')
-#        instance = Foo()
-#        instance.make_call(d)
-#    """) == {'dynamodb': set(['list_tables'])}
-#
-#
-#def test_can_track_across_classes():
-#    assert aws_calls("""\
-#        import boto3
-#        ddb = boto3.client('dynamodb')
-#        class Helper(object):
-#            def __init__(self, client):
-#                self.client = client
-#            def foo(self):
-#                return self.client.list_tables()
-#        h = Helper(ddb)
-#        h.foo()
-#    """) == {'dynamodb': set(['list_tables'])}
+#         d = boto3.client('dynamodb')
+#         instance = Foo()
+#         instance.make_call(d)
+#     """) == {'dynamodb': set(['list_tables'])}
+
+
+# def test_can_track_across_classes():
+#     assert aws_calls("""\
+#         import boto3
+#         ddb = boto3.client('dynamodb')
+#         class Helper(object):
+#             def __init__(self, client):
+#                 self.client = client
+#             def foo(self):
+#                 return self.client.list_tables()
+#         h = Helper(ddb)
+#         h.foo()
+#     """) == {'dynamodb': set(['list_tables'])}

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -9,6 +9,12 @@ from chalice import app
 from chalice import NotFoundError
 
 
+@pytest.fixture
+def view_function():
+    def _func():
+        return {"hello": "world"}
+
+
 def create_request_with_content_type(content_type):
     body = '{"json": "body"}'
     return app.Request(
@@ -515,8 +521,7 @@ def test_can_return_text_even_with_binary_content_type_configured():
     assert response['headers']['Content-Type'] == 'text/plain'
 
 
-def test_route_equality():
-    view_function = lambda: {"hello": "world"}
+def test_route_equality(view_function):
     a = app.RouteEntry(
         view_function,
         view_name='myview', path='/',
@@ -534,8 +539,7 @@ def test_route_equality():
     assert a == b
 
 
-def test_route_inequality():
-    view_function = lambda: {"hello": "world"}
+def test_route_inequality(view_function):
     a = app.RouteEntry(
         view_function,
         view_name='myview', path='/',
@@ -800,7 +804,6 @@ def test_can_handle_builtin_auth():
     def my_auth(auth_request):
         pass
 
-
     @demo.route('/', authorizer=my_auth)
     def index_view():
         return {}
@@ -882,6 +885,7 @@ def test_validation_raised_on_unknown_kwargs():
         @auth_app.authorizer(this_is_an_unknown_kwarg=True)
         def builtin_auth(auth_request):
             pass
+
 
 def test_can_return_auth_response():
     event = {
@@ -993,7 +997,6 @@ def test_can_mix_auth_routes_and_strings(auth_request):
     }
 
 
-
 def test_special_cased_root_resource(auth_request):
     # Not sure why, but API gateway uses `//` for the root
     # resource.  I've confirmed it doesn't do this for non-root
@@ -1071,7 +1074,8 @@ def test_rule_object_converts_to_str(value, unit, expected):
     assert app.Rate(value=value, unit=unit).to_string() == expected
 
 
-@pytest.mark.parametrize('minutes,hours,day_of_month,month,day_of_week,year,expected', [
+@pytest.mark.parametrize(('minutes,hours,day_of_month,month,'
+                          'day_of_week,year,expected'), [
     # These are taken from the scheduled events docs page.
     # Invoke a Lambda function at 10:00am (UTC) everyday
     (0, 10, '*', '*', '?', '*', 'cron(0 10 * * ? *)'),

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -150,9 +150,9 @@ def test_can_create_scope_obj_with_new_function():
     c = Config(chalice_stage='dev', config_from_disk=disk_config)
     new_config = c.scope(chalice_stage='dev',
                          function_name='myauth')
-    assert new_config.manage_iam_role == True
+    assert new_config.manage_iam_role
     assert new_config.iam_role_arn == 'auth-role-arn'
-    assert new_config.autogen_policy == True
+    assert new_config.autogen_policy
     assert new_config.iam_policy_file == 'function.json'
     assert new_config.environment_variables == {'env': 'function'}
     assert new_config.lambda_timeout == 2
@@ -280,8 +280,8 @@ def test_environment_from_stage_level():
         }
     }
     c = Config('prod', config_from_disk=config_from_disk)
-    assert c.environment_variables == \
-            config_from_disk['stages']['prod']['environment_variables']
+    assert c.environment_variables == (
+        config_from_disk['stages']['prod']['environment_variables'])
 
 
 def test_env_vars_chain_merge():

--- a/tests/unit/test_logs.py
+++ b/tests/unit/test_logs.py
@@ -71,7 +71,7 @@ def test_can_create_from_arn():
 
 
 def test_can_display_logs():
-    retriever = mock.Mock(sepc=logs.LogRetriever)
+    retriever = mock.Mock(spec=logs.LogRetriever)
     retriever.retrieve_logs.return_value = [
         {'timestamp': 'NOW', 'logShortId': 'shortId', 'message': 'One'},
         {'timestamp': 'NOW', 'logShortId': 'shortId', 'message': 'Two'},

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -83,7 +83,7 @@ def test_sam_injects_swagger_doc(sample_app,
                                  mock_swagger_generator,
                                  mock_policy_generator):
     p = package.SAMTemplateGenerator(mock_swagger_generator,
-                                      mock_policy_generator)
+                                     mock_policy_generator)
     mock_swagger_generator.generate_swagger.return_value = {
         'swagger': 'document'
     }
@@ -269,7 +269,7 @@ def test_fails_with_custom_auth(sample_app_with_auth,
         'swagger': 'document'
     }
     config = Config.create(
-        chalice_app=sample_app_with_auth, api_gateway_stage='dev', app_name='myapp',
-        manage_iam_role=False, iam_role_arn='role-arn')
+        chalice_app=sample_app_with_auth, api_gateway_stage='dev',
+        app_name='myapp', manage_iam_role=False, iam_role_arn='role-arn')
     with pytest.raises(package.UnsupportedFeatureError):
         p.generate_sam_template(config)

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -30,8 +30,7 @@ def test_single_call():
 
 
 def test_multiple_calls_in_same_service():
-    assert_policy_is(iam_policy({'dynamodb': set(['list_tables',
-                                                  'describe_table'])}), [{
+    expected_policy = [{
         'Effect': 'Allow',
         'Action': [
             'dynamodb:DescribeTable',
@@ -40,7 +39,11 @@ def test_multiple_calls_in_same_service():
         'Resource': [
             '*',
         ]
-    }])
+    }]
+    assert_policy_is(
+        iam_policy({'dynamodb': set(['list_tables', 'describe_table'])}),
+        expected_policy
+    )
 
 
 def test_multiple_services_used():


### PR DESCRIPTION
This PR includes no functional changes.

* Use flake8 instead of pyflakes for tests.  I had to update several tests to get a clean run of flake8
* Add a custom pylint linter that checks that `mock.patch` is never used.
* Add a custom pylint linter that checks that all `mock.Mock` calls uses a spec *keyword arg*.  I also had to fix up a few tests as a result of this linter.

I added the pylint custom linter to the pylint target in the Makefile.  Rather than having a custom pylintrc for tests (pylint does not run cleanly on the tests with our existing rcfile) I instead just added all the needed args to the command line.  It works by turning off everything and then only enabling the specific chalice linters in this PR.  The main downside to this approach is you have to update the Makefile for any new custom pylint linter you add.  I think this is ok because I imagine we won't be adding a lot of custom linters that often.

Sample output:

```
************* Module test_patches
C:  6, 9: Use of mock.patch is not allowed (patch-call)
C: 11, 8: Use of mock.patch is not allowed (patch-call)
C: 17, 4: Use of mock.patch is not allowed (patch-call)
C: 21, 4: mock.Mock() must provide "spec=" argument (mock-missing-spec)

-----------------------------------
```