### PR TITLE
Set env vars from config.json when running chalice local

### DIFF
--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -12,7 +12,7 @@ import shutil
 
 import botocore.exceptions
 import click
-from typing import Dict, Any, Optional  # noqa
+from typing import Dict, Any, Optional, MutableMapping  # noqa
 
 from chalice import __version__ as chalice_version
 from chalice.app import Chalice  # noqa
@@ -73,32 +73,33 @@ def cli(ctx, project_dir, debug=False):
     os.chdir(project_dir)
 
 
-def get_env_variables(config):
-    # type: (Dict) -> Dict
-    env_vars_key = 'environment_variables'
-    env_vars = {}  # type: Dict
-    if env_vars_key in config and config[env_vars_key]:
-        env_vars = {key: value
-                    for key, value in config[env_vars_key].items()}
-    return env_vars
-
-
 @cli.command()
 @click.option('--port', default=8000, type=click.INT)
 @click.pass_context
 def local(ctx, port=8000):
     # type: (click.Context, int) -> None
     factory = ctx.obj['factory']  # type: CLIFactory
+    run_local_server(factory, port, os.environ)
+
+
+def run_local_server(factory, port, env):
+    # type: (CLIFactory, int, MutableMapping) -> None
+    # We should add a stage argument, env vars can vary
+    # by stage.
+    config = factory.create_config_obj()
+    # We only load the chalice app after loading the config
+    # so we can set any env vars needed before importing the
+    # app.
+    env.update(config.environment_variables)
     app_obj = factory.load_chalice_app()
-    config = factory.load_project_config()
-    env_variables = get_env_variables(config)
     # When running `chalice local`, a stdout logger is configured
     # so you'll see the same stdout logging as you would when
     # running in lambda.  This is configuring the root logger.
     # The app-specific logger (app.log) will still continue
     # to work.
     logging.basicConfig(stream=sys.stdout)
-    run_local_server(app_obj, port, env_variables)
+    server = factory.create_local_server(app_obj, port)
+    server.serve_forever()
 
 
 @cli.command()
@@ -300,13 +301,6 @@ def generate_pipeline(ctx, filename):
     output = create_pipeline_template(config)
     with open(filename, 'w') as f:
         f.write(json.dumps(output, indent=2, separators=(',', ': ')))
-
-
-def run_local_server(app_obj, port, env_variables):
-    # type: (Chalice, int, Dict) -> None
-    from chalice.local import create_local_server
-    server = create_local_server(app_obj, port, env_variables=env_variables)
-    server.serve_forever()
 
 
 def main():

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -73,6 +73,16 @@ def cli(ctx, project_dir, debug=False):
     os.chdir(project_dir)
 
 
+def get_env_variables(config):
+    # type: (Dict) -> Dict
+    env_vars_key = 'environment_variables'
+    env_vars = {}  # type: Dict
+    if env_vars_key in config and config[env_vars_key]:
+        env_vars = {key: value
+                    for key, value in config[env_vars_key].items()}
+    return env_vars
+
+
 @cli.command()
 @click.option('--port', default=8000, type=click.INT)
 @click.pass_context
@@ -80,13 +90,15 @@ def local(ctx, port=8000):
     # type: (click.Context, int) -> None
     factory = ctx.obj['factory']  # type: CLIFactory
     app_obj = factory.load_chalice_app()
+    config = factory.load_project_config()
+    env_variables = get_env_variables(config)
     # When running `chalice local`, a stdout logger is configured
     # so you'll see the same stdout logging as you would when
     # running in lambda.  This is configuring the root logger.
     # The app-specific logger (app.log) will still continue
     # to work.
     logging.basicConfig(stream=sys.stdout)
-    run_local_server(app_obj, port)
+    run_local_server(app_obj, port, env_variables)
 
 
 @cli.command()
@@ -290,10 +302,10 @@ def generate_pipeline(ctx, filename):
         f.write(json.dumps(output, indent=2, separators=(',', ': ')))
 
 
-def run_local_server(app_obj, port):
-    # type: (Chalice, int) -> None
+def run_local_server(app_obj, port, env_variables):
+    # type: (Chalice, int, Dict) -> None
     from chalice.local import create_local_server
-    server = create_local_server(app_obj, port)
+    server = create_local_server(app_obj, port, env_variables=env_variables)
     server.serve_forever()
 
 

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -16,6 +16,7 @@ from chalice.package import create_app_packager
 from chalice.package import AppPackager  # noqa
 from chalice.constants import DEFAULT_STAGE_NAME
 from chalice.logs import LogRetriever
+from chalice import local
 
 
 def create_botocore_session(profile=None, debug=False):
@@ -176,3 +177,7 @@ class CLIFactory(object):
         config_file = os.path.join(self.project_dir, '.chalice', 'config.json')
         with open(config_file) as f:
             return json.loads(f.read())
+
+    def create_local_server(self, app_obj, port):
+        # type: (Chalice, int) -> local.LocalDevServer
+        return local.create_local_server(app_obj, port)

--- a/chalice/local.py
+++ b/chalice/local.py
@@ -6,6 +6,7 @@ This is intended only for local development purposes.
 from __future__ import print_function
 import base64
 import functools
+import os
 from collections import namedtuple
 
 from six.moves.BaseHTTPServer import HTTPServer
@@ -22,9 +23,10 @@ HandlerCls = Callable[..., 'ChaliceRequestHandler']
 ServerCls = Callable[..., 'HTTPServer']
 
 
-def create_local_server(app_obj, port):
-    # type: (Chalice, int) -> LocalDevServer
-    return LocalDevServer(app_obj, port)
+def create_local_server(app_obj, port, env_variables=None):
+    # type: (Chalice, int, Dict) -> LocalDevServer
+    env_variables = {} if not env_variables else env_variables
+    return LocalDevServer(app_obj, port, env_variables=env_variables)
 
 
 class RouteMatcher(object):
@@ -210,13 +212,20 @@ class ChaliceRequestHandler(BaseHTTPRequestHandler):
 
 class LocalDevServer(object):
     def __init__(self, app_object, port, handler_cls=ChaliceRequestHandler,
-                 server_cls=HTTPServer):
-        # type: (Chalice, int, HandlerCls, ServerCls) -> None
+                 server_cls=HTTPServer, env_variables=None):
+        # type: (Chalice, int, HandlerCls, ServerCls, Dict) -> None
         self.app_object = app_object
         self.port = port
         self._wrapped_handler = functools.partial(
             handler_cls, app_object=app_object)
         self.server = server_cls(('', port), self._wrapped_handler)
+        self.env_variables = {} if not env_variables else env_variables
+        self.set_env_variables()
+
+    def set_env_variables(self):
+        # type: () -> None
+        for key, value in self.env_variables.items():
+            os.environ[key] = str(value)
 
     def handle_single_request(self):
         # type: () -> None

--- a/chalice/local.py
+++ b/chalice/local.py
@@ -6,7 +6,6 @@ This is intended only for local development purposes.
 from __future__ import print_function
 import base64
 import functools
-import os
 from collections import namedtuple
 
 from six.moves.BaseHTTPServer import HTTPServer
@@ -23,10 +22,9 @@ HandlerCls = Callable[..., 'ChaliceRequestHandler']
 ServerCls = Callable[..., 'HTTPServer']
 
 
-def create_local_server(app_obj, port, env_variables=None):
-    # type: (Chalice, int, Dict) -> LocalDevServer
-    env_variables = {} if not env_variables else env_variables
-    return LocalDevServer(app_obj, port, env_variables=env_variables)
+def create_local_server(app_obj, port):
+    # type: (Chalice, int) -> LocalDevServer
+    return LocalDevServer(app_obj, port)
 
 
 class RouteMatcher(object):
@@ -212,20 +210,13 @@ class ChaliceRequestHandler(BaseHTTPRequestHandler):
 
 class LocalDevServer(object):
     def __init__(self, app_object, port, handler_cls=ChaliceRequestHandler,
-                 server_cls=HTTPServer, env_variables=None):
-        # type: (Chalice, int, HandlerCls, ServerCls, Dict) -> None
+                 server_cls=HTTPServer):
+        # type: (Chalice, int, HandlerCls, ServerCls) -> None
         self.app_object = app_object
         self.port = port
         self._wrapped_handler = functools.partial(
             handler_cls, app_object=app_object)
         self.server = server_cls(('', port), self._wrapped_handler)
-        self.env_variables = {} if not env_variables else env_variables
-        self.set_env_variables()
-
-    def set_env_variables(self):
-        # type: () -> None
-        for key, value in self.env_variables.items():
-            os.environ[key] = str(value)
 
     def handle_single_request(self):
         # type: () -> None

--- a/docs/source/topics/configfile.rst
+++ b/docs/source/topics/configfile.rst
@@ -78,7 +78,7 @@ be checked.
 
 * ``environment_variables`` - A mapping of key value pairs.  These
   key value pairs will be set as environment variables in your
-  deployed application.  All environment variables must be strings.
+  application.  All environment variables must be strings.
   If this key is specified in both a stage specific config option
   as well as a top level key, the stage specific environment
   variables will be merged into the top level keys.  See the

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -1,0 +1,18 @@
+import mock
+
+from chalice import cli
+from chalice.cli.factory import CLIFactory
+from chalice.local import LocalDevServer
+
+
+def test_run_local_server():
+    env = {}
+    factory = mock.Mock(spec=CLIFactory)
+    factory.create_config_obj.return_value.environment_variables = {
+        'foo': 'bar',
+    }
+    local_server = mock.Mock(spec=LocalDevServer)
+    factory.create_local_server.return_value = local_server
+    cli.run_local_server(factory, 8000, env)
+    assert env['foo'] == 'bar'
+    local_server.serve_forever.assert_called_with()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,7 @@
+from chalice import cli
+
+
+def test_get_env_variables():
+    config = {'environment_variables': {'test': 'true'}}
+    env_variables = cli.get_env_variables(config)
+    assert env_variables == config['environment_variables']

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,7 +1,0 @@
-from chalice import cli
-
-
-def test_get_env_variables():
-    config = {'environment_variables': {'test': 'true'}}
-    env_variables = cli.get_env_variables(config)
-    assert env_variables == config['environment_variables']

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -1,7 +1,6 @@
 import json
 import decimal
 import pytest
-import os
 from pytest import fixture
 from six import BytesIO
 
@@ -375,10 +374,3 @@ def test_can_create_lambda_event_for_post_with_formencoded_body():
 def test_can_provide_port_to_local_server(sample_app):
     dev_server = local.create_local_server(sample_app, port=23456)
     assert dev_server.server.server_port == 23456
-
-
-def test_environment_variables_set(sample_app):
-    env_variables = {'test': True}
-    local.create_local_server(sample_app, port=23456,
-                              env_variables=env_variables)
-    assert os.environ['test'] == 'True'

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -1,12 +1,13 @@
-from chalice import local, BadRequestError, CORSConfig
-from chalice import Response
 import json
 import decimal
 import pytest
+import os
 from pytest import fixture
 from six import BytesIO
 
 from chalice import app
+from chalice import local, BadRequestError, CORSConfig
+from chalice import Response
 
 
 class ChaliceStubbedHandler(local.ChaliceRequestHandler):
@@ -374,3 +375,10 @@ def test_can_create_lambda_event_for_post_with_formencoded_body():
 def test_can_provide_port_to_local_server(sample_app):
     dev_server = local.create_local_server(sample_app, port=23456)
     assert dev_server.server.server_port == 23456
+
+
+def test_environment_variables_set(sample_app):
+    env_variables = {'test': True}
+    local.create_local_server(sample_app, port=23456,
+                              env_variables=env_variables)
+    assert os.environ['test'] == 'True'


### PR DESCRIPTION
This builds on #397 and pulls up setting up the env vars up to cli/__init__.py.  We may need to pull this up even higher because we need to make sure env vars are set before ever importing the chalice app.  Otherwise we'll crash with KeyErrors on import is module level code accesses `os.environ`.

cc @stealthycoin @kyleknap 