### PR TITLE
trivial typo fix for authorizers.rst

### DIFF
--- a/docs/source/topics/authorizers.rst
+++ b/docs/source/topics/authorizers.rst
@@ -60,7 +60,7 @@ cognito user pool configured.
 
     @app.route('/user-pools', methods=['GET'], authorizer=authorizer)
     def authenticated():
-        return {"sucecss": True}
+        return {"success": True}
 
 
 For more information about using Cognito user pools with API Gateway,


### PR DESCRIPTION
Fixing a small typo I noticed in a code example for the authorization docs