### PR TITLE
Fix edge case when building packages with optional c extensions

### DIFF
--- a/chalice/compat.py
+++ b/chalice/compat.py
@@ -1,7 +1,111 @@
 import socket
 import six
+import os
 
 from six import StringIO
+
+if os.name == 'nt':
+    # windows
+    # On windows running python in a subprocess with no environment variables
+    # will cause sevral issues. In order for our subprocess to run normally we
+    # manually copy the relevant environment variables from the parent process.
+    subprocess_python_base_environ = {
+        # http://bugs.python.org/issue8557
+        'PATH': os.environ['PATH']
+    }
+    # http://bugs.python.org/issue20614
+    if 'SYSTEMROOT' in os.environ:
+        subprocess_python_base_environ['SYSTEMROOT'] = os.environ['SYSTEMROOT']
+
+    # This is the acutal patch used on windows to prevent distutils from
+    # compiling C extensions. The msvc compiler base class has its compile
+    # method overridden to raise a CompileError. This can be caught by
+    # setup.py code which can then fallback to making a purepython
+    # package if possible.
+    # We need mypy to ignore these since they are never actually called from
+    # within ourprocess they do not need to be a part of our typechecking
+    # pass.
+    def prevent_msvc_compiling_patch():  # type: ignore
+        import distutils
+        import distutils._msvccompiler
+        import distutils.msvc9compiler
+        import distutils.msvccompiler
+
+        from distutils.errors import CompileError
+
+        def raise_compile_error(*args, **kwargs):  # type: ignore
+            raise CompileError('Chalice blocked C extension compiling.')
+        distutils._msvccompiler.MSVCCompiler.compile = raise_compile_error
+        distutils.msvc9compiler.MSVCCompiler.compile = raise_compile_error
+        distutils.msvccompiler.MSVCCompiler.compile = raise_compile_error
+
+    # This is the setuptools shim used to execute setup.py by pip.
+    # Lines 2 and 3 have been added to call the above function
+    # `prevent_msvc_compiling_patch` and extra escapes have been added on line
+    # 5 because it is passed through another layer of string parsing before it
+    # is executed.
+    _SETUPTOOLS_SHIM = (
+        "import setuptools, tokenize;__file__=%r;"
+        "from chalice.compat import prevent_msvc_compiling_patch;"
+        "prevent_msvc_compiling_patch();"
+        "f=getattr(tokenize, 'open', open)(__file__);"
+        "code=f.read().replace('\\\\r\\\\n', '\\\\n');"
+        "f.close();"
+        "exec(compile(code, __file__, 'exec'))"
+    )
+
+    # On windows the C compiling story is much more complex than on posix as
+    # there are many different C compilers that setuptools and disutils will
+    # try and find using a combination of known filepaths, registry entries,
+    # and environment variables. Since there is no simple environment variable
+    # we can replace when starting the subprocess that builds the package;
+    # we need to apply a patch at runtime to prevent pip/setuptools/distutils
+    # from being able to build C extensions.
+    # Patching out every possible technique for finding each compiler would
+    # be a losing game of whack-a-mole. In addition we need to apply a patch
+    # two layers down through subprocess calls, specifically:
+    #  * Chalice creates a subprocess of `pip wheel ...` to build sdists
+    #    into wheel files.
+    #  * Pip creates another python subprocess to call the setup.py file in
+    #    the sdist. Before doing so it applies the above shim to make the
+    #    setup file compatible with setuptools. This shim layer also reads
+    #    and executes the code in the setup.py.
+    #  * Setuptools (which will have been executed by the shim) will
+    #    eventually call distutils to do the heavy lifting for C compiling.
+    #
+    # Our patch needs to affect the bottom level here (distutils) and patch
+    # it out to prevent it from compiling C in a graceful way that results in
+    # falling back to building a purepython library if possible.
+    # The below line will be injected just before the `pip wheel ...` portion
+    # of the subprocess that Chalice starts. This replaces the
+    # SETUPTOOLS_SHIM that pip normally uses with the one defined above.
+    # When pip goes to run its subprocess for executing setup.py it will
+    # inject _SETUPTOOLS_SHIM rather than the usual SETUPTOOLS_SHIM in pip.
+    # This lets us apply our patches in the same process that will compile
+    # the c extensions before the setup.py file has been executed.
+    # The actual patches used are decribed in the comment above
+    # _SETUPTOOLS_SHIM.
+    pip_no_compile_c_shim = (
+        "import pip;"
+        "pip.wheel.SETUPTOOLS_SHIM = \"\"\"%s\"\"\";"
+    ) % _SETUPTOOLS_SHIM
+    pip_no_compile_c_env_vars = {}  # type: ignore
+else:
+    # posix
+    # On posix you can start python in a subprocess with no environment
+    # variables and it will run normally.
+    subprocess_python_base_environ = {}
+
+    # On posix systems setuptools/distutils uses the CC env variable to
+    # locate a C compiler for building C extensions. All we need to do is set
+    # it to /var/false, and the module building process will fail to build.
+    # C extensions, and any fallback processes in place to build a pure python
+    # package will be kicked off.
+    # No need to monkey patch the process.
+    pip_no_compile_c_shim = ''
+    pip_no_compile_c_env_vars = {
+        'CC': '/var/false'
+    }
 
 
 if six.PY3:

--- a/chalice/compat.py
+++ b/chalice/compat.py
@@ -2,28 +2,30 @@ import socket
 import six
 import os
 
+from typing import Dict, Any  # noqa
+
 from six import StringIO
 
 if os.name == 'nt':
     # windows
     # On windows running python in a subprocess with no environment variables
-    # will cause sevral issues. In order for our subprocess to run normally we
+    # will cause several issues. In order for our subprocess to run normally we
     # manually copy the relevant environment variables from the parent process.
     subprocess_python_base_environ = {
         # http://bugs.python.org/issue8557
         'PATH': os.environ['PATH']
-    }
+    }  # type: Dict[str, Any]
     # http://bugs.python.org/issue20614
     if 'SYSTEMROOT' in os.environ:
         subprocess_python_base_environ['SYSTEMROOT'] = os.environ['SYSTEMROOT']
 
-    # This is the acutal patch used on windows to prevent distutils from
+    # This is the actual patch used on windows to prevent distutils from
     # compiling C extensions. The msvc compiler base class has its compile
     # method overridden to raise a CompileError. This can be caught by
-    # setup.py code which can then fallback to making a purepython
+    # setup.py code which can then fallback to making a pure python
     # package if possible.
     # We need mypy to ignore these since they are never actually called from
-    # within ourprocess they do not need to be a part of our typechecking
+    # within our process they do not need to be a part of our typechecking
     # pass.
     def prevent_msvc_compiling_patch():  # type: ignore
         import distutils
@@ -45,13 +47,13 @@ if os.name == 'nt':
     # 5 because it is passed through another layer of string parsing before it
     # is executed.
     _SETUPTOOLS_SHIM = (
-        "import setuptools, tokenize;__file__=%r;"
-        "from chalice.compat import prevent_msvc_compiling_patch;"
-        "prevent_msvc_compiling_patch();"
-        "f=getattr(tokenize, 'open', open)(__file__);"
-        "code=f.read().replace('\\\\r\\\\n', '\\\\n');"
-        "f.close();"
-        "exec(compile(code, __file__, 'exec'))"
+        r"import setuptools, tokenize;__file__=%r;"
+        r"from chalice.compat import prevent_msvc_compiling_patch;"
+        r"prevent_msvc_compiling_patch();"
+        r"f=getattr(tokenize, 'open', open)(__file__);"
+        r"code=f.read().replace('\\r\\n', '\\n');"
+        r"f.close();"
+        r"exec(compile(code, __file__, 'exec'))"
     )
 
     # On windows the C compiling story is much more complex than on posix as
@@ -86,10 +88,10 @@ if os.name == 'nt':
     # The actual patches used are decribed in the comment above
     # _SETUPTOOLS_SHIM.
     pip_no_compile_c_shim = (
-        "import pip;"
-        "pip.wheel.SETUPTOOLS_SHIM = \"\"\"%s\"\"\";"
+        'import pip;'
+        'pip.wheel.SETUPTOOLS_SHIM = """%s""";'
     ) % _SETUPTOOLS_SHIM
-    pip_no_compile_c_env_vars = {}  # type: ignore
+    pip_no_compile_c_env_vars = {}  # type: Dict[str, Any]
 else:
     # posix
     # On posix you can start python in a subprocess with no environment

--- a/chalice/deploy/packager.py
+++ b/chalice/deploy/packager.py
@@ -384,8 +384,8 @@ class DependencyBuilder(object):
 
         # Re-count the wheel files after the second download pass. Anything
         # that has an sdist but not a valid wheel file is still not going to
-        # work on lambda and our we must now try and build the sdist into a
-        # wheel file ourselves.
+        # work on lambda and we must now try and build the sdist into a wheel
+        # file ourselves.
         compatible_wheels, incompatible_wheels = self._categorize_wheel_files(
             directory)
         missing_wheels = sdists - compatible_wheels

--- a/docs/source/topics/packaging.rst
+++ b/docs/source/topics/packaging.rst
@@ -50,7 +50,9 @@ specific examples).  The ``vendor/`` directory is helpful in these scenarios:
 * You need to include custom packages or binary content that is not accessible
   via ``pip``.  These may be internal packages that aren't public.
 * Wheel files are not available for a package you need from pip.
-
+* A package is installable with ``requirements.txt`` but has optional c
+  extensions. Chalice can build the dependency without the c extensions, but
+  if you want better performance you can vendor a version that is compiled.
 
 As a general rule of thumb, code that you write goes in either ``app.py`` or
 ``chalicelib/``, and dependencies are either specified in ``requirements.txt``

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,12 @@
 import zipfile
+from collections import namedtuple
 
 import botocore.session
 from botocore.stub import Stubber
 from pytest import fixture
+
+
+FakePipCall = namedtuple('FakePipEntry', ['args', 'env_vars', 'shim'])
 
 
 class FakeSdistBuilder(object):


### PR DESCRIPTION
The edge case occurs when a package can compile optional c speedups
which succeed during the build process but lock the generated wheel file
to the arch the package was built on. This makes the wheel file
incompatible with lambda and causes it to fail to add that dependency
even though it could have by building it without the optional c
extensions.

This is a bit tricky to fix as means we need to selectively break the
ability to compile c extensions during some runs of our wheel building
phase. It is also quite different on POSIX and Windows.

cc @kyleknap @jamesls @dstufft 