### PR TITLE
Fix issue where role updates happened twice

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ CHANGELOG
 * Remove legacy ``policy.json`` file support. Policy files must
   use the stage name, e.g. ``policy-dev.json``
   (`#430 <https://github.com/awslabs/chalice/pull/540>`__)
+* Fix issue where IAM role policies were updated twice on redeploys
+  (`#428 <https://github.com/awslabs/chalice/pull/428>`__)
 
 
 1.0.0b1

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -483,7 +483,6 @@ class LambdaDeployer(object):
                     existing_resources.api_handler_name):
             handler_name = existing_resources.api_handler_name
             self._confirm_any_runtime_changes(config, handler_name)
-            self._get_or_create_lambda_role_arn(config, handler_name)
             self._update_lambda_function(config, handler_name, stage_name)
             function_arn = existing_resources.api_handler_arn
             deployed_values['api_handler_name'] = handler_name


### PR DESCRIPTION
There weren't any tests for this code path and this didn't break
anything, it's just entirely unnecessary.  Looks like this was a result
of an improper refactoring.