### PR TITLE
Remove legacy policy.json fallback

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ CHANGELOG
   (`#396 <https://github.com/awslabs/chalice/issues/396>`__)
 * Fix edge case when building packages with optional c extensions
   (`#421 <https://github.com/awslabs/chalice/pull/421>`__)
+* Remove legacy ``policy.json`` file support. Policy files must
+  use the stage name, e.g. ``policy-dev.json``
 
 
 1.0.0b1

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -899,11 +899,4 @@ class ApplicationPolicyHandler(object):
             # to a fixed name based on the stage.
             basename = 'policy-%s.json' % config.chalice_stage
             filename = os.path.join(config.project_dir, '.chalice', basename)
-            if not self._osutils.file_exists(filename) and \
-                    config.chalice_stage == DEFAULT_STAGE_NAME:
-                # There's a special back-compat case where we'll
-                # try to load .chalice/policy.json if you're using
-                # the default dev stage.
-                filename = os.path.join(config.project_dir,
-                                        '.chalice', 'policy.json')
         return filename

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -213,24 +213,11 @@ def test_can_load_non_stage_specific_name(app_policy, in_memory_osutils):
     # existing use cases we'll look for .chalice/policy.json only
     # if you're in dev stage.
     previous_policy = '{"Statement": ["foo"]}'
-    filename = os.path.join('.', '.chalice', 'policy.json')
+    filename = os.path.join('.', '.chalice', 'policy-dev.json')
     in_memory_osutils.filemap[filename] = previous_policy
     config = Config.create(project_dir='.', autogen_policy=False)
     generated = app_policy.generate_policy_from_app_source(config)
     assert generated == json.loads(previous_policy)
-
-
-def test_legacy_file_not_loaded_in_non_dev_stage(app_policy,
-                                                 in_memory_osutils):
-    previous_policy = '{"Statement": ["foo"]}'
-    filename = os.path.join('.', '.chalice', 'policy.json')
-    in_memory_osutils.filemap[filename] = previous_policy
-    config = Config.create(project_dir='.', autogen_policy=False,
-                           chalice_stage='not-dev')
-    generated = app_policy.generate_policy_from_app_source(config)
-    # We should not have loaded the previously policy from policy.json
-    # because that's only supported for the 'dev' stage.
-    assert generated != json.loads(previous_policy)
 
 
 def test_can_provide_stage_specific_policy_file(app_policy, in_memory_osutils):


### PR DESCRIPTION
That was put in place for apps before the introduction of
chalice stages.  Now the policy name must have the stage name.