### PR TITLE
Validate route cannot be the empty string

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ CHANGELOG
   (`#430 <https://github.com/awslabs/chalice/pull/540>`__)
 * Fix issue where IAM role policies were updated twice on redeploys
   (`#428 <https://github.com/awslabs/chalice/pull/428>`__)
+* Validate route path is not an empty string
+  (`#432 <https://github.com/awslabs/chalice/pull/432>`__)
 
 
 1.0.0b1

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -89,6 +89,8 @@ def validate_routes(routes):
     #
     # * any routes that end with a trailing slash.
     for route_name, methods in routes.items():
+        if not route_name:
+            raise ValueError("Route cannot be the empty string")
         if route_name != '/' and route_name.endswith('/'):
             raise ValueError("Route cannot end with a trailing slash: %s"
                              % route_name)

--- a/tests/unit/deploy/test_deployer.py
+++ b/tests/unit/deploy/test_deployer.py
@@ -302,6 +302,14 @@ def test_trailing_slash_routes_result_in_error():
         validate_configuration(config)
 
 
+def test_empty_route_results_in_error():
+    app = Chalice('appname')
+    app.routes = {'': {}}
+    config = Config.create(chalice_app=app)
+    with pytest.raises(ValueError):
+        validate_configuration(config)
+
+
 def test_validate_python_version_invalid():
     config = mock.Mock(spec=Config)
     config.lambda_python_version = 'python1.0'


### PR DESCRIPTION
This results in an opaque error message when you try to deploy.