### PR TITLE
Make integ tests more robust

### DIFF
--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -212,6 +212,7 @@ def _get_all_function_names(chalice_app):
 class ChaliceDeploymentError(Exception):
     def __init__(self, error):
         # type: (Exception) -> None
+        self.original_error = error
         where = self._get_error_location(error)
         msg = self._wrap_text(
             'ERROR - %s, received the following error:' % where

--- a/tests/integration/testapp/.chalice/config.json
+++ b/tests/integration/testapp/.chalice/config.json
@@ -1,0 +1,9 @@
+{
+  "stages": {
+    "dev": {
+      "api_gateway_stage": "api"
+    }
+  },
+  "version": "2.0",
+  "app_name": "smoketestapp"
+}


### PR DESCRIPTION
This introduces changes to make the integ tests more robust to transient failures:


1. Create a tmpdir and copy the testapp over to this directory.  That way none of the files are mutated in `tests/integration` during the test run.
2. Add a retry loop for the app deployment.  This helps when you get throttled by API Gateway when deploying your app.

I had to make one addition to the deployer to record the original error in the `ChaliceDeploymentError`.  I only wanted to retry if we were getting throttled and would prefer to check against the specific error code vs. string matching the generated error message.